### PR TITLE
Remove redundant postcode validation

### DIFF
--- a/deprivation_scores/general_functions/__init__.py
+++ b/deprivation_scores/general_functions/__init__.py
@@ -2,6 +2,5 @@ from .postcode import (
     lsoa_for_postcode,
     regions_for_postcode,
     local_authority_district_code_for_postcode,
-    is_valid_postcode,
 )
 from .quantile import quantile_for_rank

--- a/deprivation_scores/general_functions/postcode.py
+++ b/deprivation_scores/general_functions/postcode.py
@@ -46,14 +46,3 @@ def local_authority_district_code_for_postcode(postcode):
     serialised = response.json()
     lad = serialised["result"]["codes"]["admin_district"]
     return lad
-
-
-def is_valid_postcode(postcode):
-
-    url = f"https://api.postcodes.io/postcodes/{postcode}/validate"
-    response = requests.get(url=url)
-    if response.status_code == 404:
-        print("Postcode validation failure. Could not validate postcode.")
-        return False
-    else:
-        return response.json()["result"]

--- a/deprivation_scores/views.py
+++ b/deprivation_scores/views.py
@@ -51,7 +51,6 @@ from .serializers import (
 from .general_functions import (
     lsoa_for_postcode,
     regions_for_postcode,
-    is_valid_postcode,
 )
 
 
@@ -467,56 +466,55 @@ class UKIndexMultipleDeprivationQuantileView(APIView):
         post_code = self.request.query_params.get("postcode", None)
         requested_quantile = self.request.query_params.get("quantile", None)
         if post_code:
-            if is_valid_postcode(postcode=post_code):
-                lsoa_object = lsoa_for_postcode(postcode=post_code)
-                if lsoa_object["lsoa"]:
-                    lsoa_code = lsoa_object["lsoa"]
-                    if lsoa_object["country"] == "England":
-                        lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
-                        imd = EnglishIndexMultipleDeprivation.objects.filter(
-                            lsoa=lsoa
-                        ).get()
-                        data = quantile_for_rank(
-                            rank=imd.imd_rank,
-                            requested_quantile=requested_quantile,
-                            country="england",
-                        )
-                        response = Response({"result": data})
-                    elif lsoa_object["country"] == "Wales":
-                        lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
-                        imd = WelshIndexMultipleDeprivation.objects.filter(
-                            lsoa=lsoa
-                        ).get()
-                        data = quantile_for_rank(
-                            rank=imd.imd_rank,
-                            requested_quantile=requested_quantile,
-                            country="wales",
-                        )
-                        response = Response({"result": data})
-                    elif lsoa_object["country"] == "Scotland":
-                        lsoa = DataZone.objects.filter(data_zone_code=lsoa_code).get()
-                        imd = ScottishIndexMultipleDeprivation.objects.filter(
-                            data_zone=lsoa
-                        ).get()
-                        data = quantile_for_rank(
-                            rank=imd.imd_rank,
-                            requested_quantile=requested_quantile,
-                            country="scotland",
-                        )
-                        response = Response({"result": data})
-                    elif lsoa_object["country"] == "Northern Ireland":
-                        lsoa = SOA.objects.filter(soa_code=lsoa_code).get()
-                        imd = NorthernIrelandIndexMultipleDeprivation.objects.filter(
-                            soa=lsoa
-                        ).get()
-                        data = quantile_for_rank(
-                            rank=imd.imd_rank,
-                            requested_quantile=requested_quantile,
-                            country="northern_ireland",
-                        )
-                        response = Response({"result": data})
-                    else:
-                        raise ParseError("No valid country supplied.", code=400)
+            lsoa_object = lsoa_for_postcode(postcode=post_code)
+            if lsoa_object["lsoa"]:
+                lsoa_code = lsoa_object["lsoa"]
+                if lsoa_object["country"] == "England":
+                    lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
+                    imd = EnglishIndexMultipleDeprivation.objects.filter(
+                        lsoa=lsoa
+                    ).get()
+                    data = quantile_for_rank(
+                        rank=imd.imd_rank,
+                        requested_quantile=requested_quantile,
+                        country="england",
+                    )
+                    response = Response({"result": data})
+                elif lsoa_object["country"] == "Wales":
+                    lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
+                    imd = WelshIndexMultipleDeprivation.objects.filter(
+                        lsoa=lsoa
+                    ).get()
+                    data = quantile_for_rank(
+                        rank=imd.imd_rank,
+                        requested_quantile=requested_quantile,
+                        country="wales",
+                    )
+                    response = Response({"result": data})
+                elif lsoa_object["country"] == "Scotland":
+                    lsoa = DataZone.objects.filter(data_zone_code=lsoa_code).get()
+                    imd = ScottishIndexMultipleDeprivation.objects.filter(
+                        data_zone=lsoa
+                    ).get()
+                    data = quantile_for_rank(
+                        rank=imd.imd_rank,
+                        requested_quantile=requested_quantile,
+                        country="scotland",
+                    )
+                    response = Response({"result": data})
+                elif lsoa_object["country"] == "Northern Ireland":
+                    lsoa = SOA.objects.filter(soa_code=lsoa_code).get()
+                    imd = NorthernIrelandIndexMultipleDeprivation.objects.filter(
+                        soa=lsoa
+                    ).get()
+                    data = quantile_for_rank(
+                        rank=imd.imd_rank,
+                        requested_quantile=requested_quantile,
+                        country="northern_ireland",
+                    )
+                    response = Response({"result": data})
+                else:
+                    raise ParseError("No valid country supplied.", code=400)
             else:
                 # postcode not valid
                 raise ParseError("Invalid postcode supplied.", code=400)

--- a/deprivation_scores/views.py
+++ b/deprivation_scores/views.py
@@ -353,45 +353,44 @@ class UKIndexMultipleDeprivationView(APIView):
         """
         post_code = self.request.query_params.get("postcode", None)
         if post_code:
-            if is_valid_postcode(postcode=post_code):
-                lsoa_object = lsoa_for_postcode(postcode=post_code)
+            lsoa_object = lsoa_for_postcode(postcode=post_code)
 
-                if lsoa_object["lsoa"]:
-                    lsoa_code = lsoa_object["lsoa"]
-                    if lsoa_object["country"] == "England":
-                        lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
-                        imd = EnglishIndexMultipleDeprivation.objects.filter(
-                            lsoa=lsoa
-                        ).get()
-                        response = self.english_serializer_class(
-                            instance=imd, context={"request": request}
-                        )
-                    elif lsoa_object["country"] == "Wales":
-                        lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
-                        imd = WelshIndexMultipleDeprivation.objects.filter(
-                            lsoa=lsoa
-                        ).get()
-                        response = self.welsh_serializer_class(
-                            instance=imd, context={"request": request}
-                        )
-                    elif lsoa_object["country"] == "Scotland":
-                        lsoa = DataZone.objects.filter(data_zone_code=lsoa_code).get()
-                        imd = ScottishIndexMultipleDeprivation.objects.filter(
-                            data_zone=lsoa
-                        ).get()
-                        response = self.scottish_serializer_class(
-                            instance=imd, context={"request": request}
-                        )
-                    elif lsoa_object["country"] == "Northern Ireland":
-                        lsoa = SOA.objects.filter(soa_code=lsoa_code).get()
-                        imd = NorthernIrelandIndexMultipleDeprivation.objects.filter(
-                            soa=lsoa
-                        ).get()
-                        response = self.northern_ireland_serializer_class(
-                            instance=imd, context={"request": request}
-                        )
-                    else:
-                        raise ParseError("No valid country supplied.", code=400)
+            if lsoa_object["lsoa"]:
+                lsoa_code = lsoa_object["lsoa"]
+                if lsoa_object["country"] == "England":
+                    lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
+                    imd = EnglishIndexMultipleDeprivation.objects.filter(
+                        lsoa=lsoa
+                    ).get()
+                    response = self.english_serializer_class(
+                        instance=imd, context={"request": request}
+                    )
+                elif lsoa_object["country"] == "Wales":
+                    lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
+                    imd = WelshIndexMultipleDeprivation.objects.filter(
+                        lsoa=lsoa
+                    ).get()
+                    response = self.welsh_serializer_class(
+                        instance=imd, context={"request": request}
+                    )
+                elif lsoa_object["country"] == "Scotland":
+                    lsoa = DataZone.objects.filter(data_zone_code=lsoa_code).get()
+                    imd = ScottishIndexMultipleDeprivation.objects.filter(
+                        data_zone=lsoa
+                    ).get()
+                    response = self.scottish_serializer_class(
+                        instance=imd, context={"request": request}
+                    )
+                elif lsoa_object["country"] == "Northern Ireland":
+                    lsoa = SOA.objects.filter(soa_code=lsoa_code).get()
+                    imd = NorthernIrelandIndexMultipleDeprivation.objects.filter(
+                        soa=lsoa
+                    ).get()
+                    response = self.northern_ireland_serializer_class(
+                        instance=imd, context={"request": request}
+                    )
+                else:
+                    raise ParseError("No valid country supplied.", code=400)
             else:
                 # postcode not valid
                 raise ParseError("Invalid postcode supplied.", code=400)


### PR DESCRIPTION
`/validate` does the [same underlying database lookup](https://github.com/ideal-postcodes/postcodes.io/blob/656f16bb2cc9807f4ad3adada9c83658daf269c2/src/app/controllers/postcodes_controller.ts#L40) at their end as the normal API so we don't need the additional call. This makes the API about twice as fast.

*Before*

```
time curl 'http://localhost:8001/index_of_multiple_deprivation_quantile?postcode=W1A1AA&quantile=5'
{"result":{"rank":15472,"requested_quantile":5,"requested_quantile_name":"quintile","data_quantile":3,"country":"england","error":null}}
real    0m0.186s
user    0m0.002s
sys     0m0.003s
```

*After*

```
time curl 'http://localhost:8001/index_of_multiple_deprivation_quantile?postcode=W1A1AA&quantile=5'
{"result":{"rank":15472,"requested_quantile":5,"requested_quantile_name":"quintile","data_quantile":3,"country":"england","error":null}}
real    0m0.103s
user    0m0.002s
sys     0m0.003s
```