### PR TITLE
Update live_rcpch-census-engine.yml

### DIFF
--- a/.github/workflows/live_rcpch-census-engine.yml
+++ b/.github/workflows/live_rcpch-census-engine.yml
@@ -33,7 +33,7 @@ jobs:
       # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
       
       - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: python-app
           path: |
@@ -49,13 +49,13 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: python-app
           path: .
           
       - name: 'Deploy to Azure Web App'
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v4
         id: deploy-to-webapp
         with:
           app-name: 'rcpch-census-engine'


### PR DESCRIPTION
`v2` of upload action is deprecated, bump to `v4`

https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/

Failing deploy: https://github.com/rcpch/rcpch-census-platform/actions/runs/13412019752