### PR TITLE
[Bug Fix] Gracefully handle invalid postcode

### DIFF
--- a/deprivation_scores/general_functions/__init__.py
+++ b/deprivation_scores/general_functions/__init__.py
@@ -1,6 +1,5 @@
 from .postcode import (
     lsoa_for_postcode,
     regions_for_postcode,
-    local_authority_district_code_for_postcode,
 )
 from .quantile import quantile_for_rank

--- a/deprivation_scores/general_functions/postcode.py
+++ b/deprivation_scores/general_functions/postcode.py
@@ -1,48 +1,94 @@
+from typing import Literal, TypedDict
 import requests
 from pprint import pprint
 
 
-def lsoa_for_postcode(postcode):
+def get_postcode_info(postcode: str):
+    # Clean
     postcode = postcode.replace(" ", "")
 
-    url = "https://api.postcodes.io/postcodes/" + postcode
-    response = requests.get(url=url)
+    # Make response
+    postcodes_url = f"https://api.postcodes.io/postcodes/{postcode}"
+    try:
+        response = requests.get(postcodes_url)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as err:
+        print(f"HTTP ERROR: {err}")
+    except Exception as err:
+        print(f"Other error occurred: {err}")
 
-    if response.status_code == 404:
-        print("Could not get LSOA from postcode.")
-        return None
+    return None
 
-    serialised = response.json()
-    country = serialised["result"]["country"]
-    lsoa = serialised["result"]["codes"]["lsoa"]
-    return {"lsoa": lsoa, "country": country}
+
+def get_terminated_postcode_info(postcode: str):
+    # Clean
+    postcode = postcode.replace(" ", "")
+
+    # Make response
+    terminated_postcodes_url = f"https://api.postcodes.io/terminated_postcodes/{postcode}"
+    try:
+        response = requests.get(terminated_postcodes_url)
+        response.raise_for_status()
+        print(f"Terminated postcode found: {postcode}")
+        return response.json()
+    except requests.exceptions.HTTPError as err:
+        print(f"HTTP ERROR: {err}")
+    except Exception as err:
+        print(f"Other error occurred: {err}")
+
+    return None
+
+
+class LSOAPostcodeObject(TypedDict):
+    status: Literal["success", "error", "terminated_postcode"]
+    response: dict | str
+
+
+def get_postcode_data(postcode: str) -> dict:
+    if not (data := get_postcode_info(postcode)):
+        # Try terminated postcode endpoint
+        print("Trying terminated postcode url...")
+        if not (terminated_postcode_info := get_terminated_postcode_info(postcode)):
+            return {
+                "status": "error",
+                "response": "Could not get LSOA from postcode.",
+            }
+        print(f"Terminated postcode info: {terminated_postcode_info}")
+        return {
+            "status": "terminated_postcode",
+            "response": terminated_postcode_info.get("result"),
+        }
+    return {
+        "status": "success",
+        "response": data,
+    }
+
+
+def lsoa_for_postcode(postcode):
+    data = get_postcode_data(postcode)
+    if data["status"] != "success":
+        return data
+    
+    data = data["response"]
+    country = data["result"]["country"]
+    lsoa = data["result"]["codes"]["lsoa"]
+    response = {"lsoa": lsoa, "country": country}
+    return {
+        "status": "success",
+        "response": response,
+    }
 
 
 def regions_for_postcode(postcode):
-    postcode = postcode.replace(" ", "")
-
-    url = "https://api.postcodes.io/postcodes/" + postcode
-    response = requests.get(url=url)
-
-    if response.status_code == 404:
-        print("Could not get LSOA from postcode.")
-        return None
-
-    serialised = response.json()
-    lsoa = serialised["result"]["codes"]["lsoa"]
-    return serialised["result"]
+    data = get_postcode_data(postcode)
+    return data
 
 
 def local_authority_district_code_for_postcode(postcode):
-    postcode = postcode.replace(" ", "")
+    serialised = get_postcode_data(postcode)
+    if serialised["status"] != "success":
+        return serialised
 
-    url = "https://api.postcodes.io/postcodes/" + postcode
-    response = requests.get(url=url)
-
-    if response.status_code == 404:
-        print("Could not get LSOA from postcode.")
-        return None
-
-    serialised = response.json()
     lad = serialised["result"]["codes"]["admin_district"]
     return lad

--- a/deprivation_scores/general_functions/postcode.py
+++ b/deprivation_scores/general_functions/postcode.py
@@ -69,7 +69,7 @@ def lsoa_for_postcode(postcode):
     data = get_postcode_data(postcode)
     if data["status"] != "success":
         return data
-    
+
     data = data["response"]
     country = data["result"]["country"]
     lsoa = data["result"]["codes"]["lsoa"]
@@ -83,12 +83,3 @@ def lsoa_for_postcode(postcode):
 def regions_for_postcode(postcode):
     data = get_postcode_data(postcode)
     return data
-
-
-def local_authority_district_code_for_postcode(postcode):
-    serialised = get_postcode_data(postcode)
-    if serialised["status"] != "success":
-        return serialised
-
-    lad = serialised["result"]["codes"]["admin_district"]
-    return lad

--- a/deprivation_scores/views.py
+++ b/deprivation_scores/views.py
@@ -294,7 +294,8 @@ class PostcodeView(APIView):
         """
         postcode = request.query_params.get("postcode")
         if postcode:
-            response = regions_for_postcode(postcode=postcode)
+            if not (response := regions_for_postcode(postcode=postcode)):
+                raise ParseError(detail="Invalid postcode supplied.")
             return Response(response)
         else:
             raise ParseError(detail="Postcode cannot be blank")
@@ -466,7 +467,8 @@ class UKIndexMultipleDeprivationQuantileView(APIView):
         post_code = self.request.query_params.get("postcode", None)
         requested_quantile = self.request.query_params.get("quantile", None)
         if post_code:
-            lsoa_object = lsoa_for_postcode(postcode=post_code)
+            if not (lsoa_object := lsoa_for_postcode(postcode=post_code)):
+                raise ParseError("Invalid postcode supplied.", code=400)
             if lsoa_object["lsoa"]:
                 lsoa_code = lsoa_object["lsoa"]
                 if lsoa_object["country"] == "England":

--- a/deprivation_scores/views.py
+++ b/deprivation_scores/views.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from rest_framework import (
     viewsets,
     serializers,  # serializers here required for drf-spectacular @extend_schema
@@ -130,13 +131,13 @@ class LSOAViewSet(viewsets.ReadOnlyModelViewSet):
 class SOAViewSet(viewsets.ReadOnlyModelViewSet):
     """
     This endpoint returns a list of SOAs in Northern Ireland.
-    
+
     Filter Parameters:
 
     `year`
-    
+
     `soa_code`
-    
+
     `soa_name`
 
     If none are passed, a list is returned.
@@ -168,13 +169,13 @@ class GreenSpaceViewSet(viewsets.ReadOnlyModelViewSet):
 class DataZoneViewSet(viewsets.ReadOnlyModelViewSet):
     """
     This endpoint returns a list of all Scottish data zones (2011) and their associated local authority district.
-    
+
     Filter Parameters:
 
     `year`
-    
+
     `data_zone_code`
-    
+
     `data_zone_name`
 
     If none are passed, a list is returned.
@@ -209,7 +210,7 @@ class EnglishIndexMultipleDeprivationViewSet(viewsets.ReadOnlyModelViewSet):
 class WelshMultipleDeprivationViewSet(viewsets.ReadOnlyModelViewSet):
     """
     This endpoint returns a list of Welsh LSOAs with the associated deprivation rank and quintiles, as well as the rank and quintile of all the associated deprivation domains (2019).
-    
+
     Filter Parameters:
 
     `lsoa_code`
@@ -229,7 +230,7 @@ class WelshMultipleDeprivationViewSet(viewsets.ReadOnlyModelViewSet):
 class ScottishMultipleDeprivationViewSet(viewsets.ReadOnlyModelViewSet):
     """
     This endpoint returns a list of Scottish data zones with the associated deprivation rank and quintiles, as well as the rank and quintile of all the associated deprivation domains (2017).
-    
+
     Filter Parameters:
 
     `data_zone_code`
@@ -257,9 +258,7 @@ class NorthernIrelandMultipleDeprivationViewSet(viewsets.ReadOnlyModelViewSet):
     If none are passed, a list is returned.
     """
 
-    queryset = NorthernIrelandIndexMultipleDeprivation.objects.all().order_by(
-        "-imd_rank"
-    )
+    queryset = NorthernIrelandIndexMultipleDeprivation.objects.all().order_by("-imd_rank")
     serializer_class = NorthernIrelandIndexMultipleDeprivationSerializer
     filterset_class = NorthernIrelandIndexMultipleDeprivationFilter
     filter_backends = [DjangoFilterBackend]
@@ -294,8 +293,16 @@ class PostcodeView(APIView):
         """
         postcode = request.query_params.get("postcode")
         if postcode:
-            if not (response := regions_for_postcode(postcode=postcode)):
-                raise ParseError(detail="Invalid postcode supplied.")
+
+            data = regions_for_postcode(postcode=postcode)
+            status = data["status"]
+
+            response = data["response"]
+            if status == "error":
+                raise ParseError(response, code=400)
+            elif status == "terminated_postcode":
+                return Response(response, status=HTTPStatus.GONE)
+
             return Response(response)
         else:
             raise ParseError(detail="Postcode cannot be blank")
@@ -305,9 +312,7 @@ class UKIndexMultipleDeprivationView(APIView):
     english_serializer_class = EnglishIndexMultipleDeprivationSerializer
     welsh_serializer_class = WelshIndexMultipleDeprivationSerializer
     scottish_serializer_class = ScottishIndexMultipleDeprivationSerializer
-    northern_ireland_serializer_class = (
-        NorthernIrelandIndexMultipleDeprivationSerializer
-    )
+    northern_ireland_serializer_class = NorthernIrelandIndexMultipleDeprivationSerializer
 
     @extend_schema(
         parameters=[
@@ -353,40 +358,39 @@ class UKIndexMultipleDeprivationView(APIView):
         """
         post_code = self.request.query_params.get("postcode", None)
         if post_code:
-            if not (lsoa_object := lsoa_for_postcode(postcode=post_code)):
-                raise ParseError("Invalid postcode supplied.", code=400)
+            data = lsoa_for_postcode(postcode=post_code)
+            status = data["status"]
+            response = data["response"]
+            if status == "error":
+                raise ParseError(response, code=400)
+            elif status == "terminated_postcode":
+                return Response(response, status=HTTPStatus.GONE)
+
+            lsoa_object = response
 
             if lsoa_object["lsoa"]:
                 lsoa_code = lsoa_object["lsoa"]
                 if lsoa_object["country"] == "England":
                     lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
-                    imd = EnglishIndexMultipleDeprivation.objects.filter(
-                        lsoa=lsoa
-                    ).get()
+                    imd = EnglishIndexMultipleDeprivation.objects.filter(lsoa=lsoa).get()
                     response = self.english_serializer_class(
                         instance=imd, context={"request": request}
                     )
                 elif lsoa_object["country"] == "Wales":
                     lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
-                    imd = WelshIndexMultipleDeprivation.objects.filter(
-                        lsoa=lsoa
-                    ).get()
+                    imd = WelshIndexMultipleDeprivation.objects.filter(lsoa=lsoa).get()
                     response = self.welsh_serializer_class(
                         instance=imd, context={"request": request}
                     )
                 elif lsoa_object["country"] == "Scotland":
                     lsoa = DataZone.objects.filter(data_zone_code=lsoa_code).get()
-                    imd = ScottishIndexMultipleDeprivation.objects.filter(
-                        data_zone=lsoa
-                    ).get()
+                    imd = ScottishIndexMultipleDeprivation.objects.filter(data_zone=lsoa).get()
                     response = self.scottish_serializer_class(
                         instance=imd, context={"request": request}
                     )
                 elif lsoa_object["country"] == "Northern Ireland":
                     lsoa = SOA.objects.filter(soa_code=lsoa_code).get()
-                    imd = NorthernIrelandIndexMultipleDeprivation.objects.filter(
-                        soa=lsoa
-                    ).get()
+                    imd = NorthernIrelandIndexMultipleDeprivation.objects.filter(soa=lsoa).get()
                     response = self.northern_ireland_serializer_class(
                         instance=imd, context={"request": request}
                     )
@@ -468,15 +472,23 @@ class UKIndexMultipleDeprivationQuantileView(APIView):
         post_code = self.request.query_params.get("postcode", None)
         requested_quantile = self.request.query_params.get("quantile", None)
         if post_code:
-            if not (lsoa_object := lsoa_for_postcode(postcode=post_code)):
-                raise ParseError("Invalid postcode supplied.", code=400)
+
+            data = lsoa_for_postcode(postcode=post_code)
+
+            status = data["status"]
+            response = data["response"]
+            if status == "error":
+                raise ParseError(response, code=400)
+            elif status == "terminated_postcode":
+                return Response(response, status=HTTPStatus.GONE)
+
+            lsoa_object = response
+
             if lsoa_object["lsoa"]:
                 lsoa_code = lsoa_object["lsoa"]
                 if lsoa_object["country"] == "England":
                     lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
-                    imd = EnglishIndexMultipleDeprivation.objects.filter(
-                        lsoa=lsoa
-                    ).get()
+                    imd = EnglishIndexMultipleDeprivation.objects.filter(lsoa=lsoa).get()
                     data = quantile_for_rank(
                         rank=imd.imd_rank,
                         requested_quantile=requested_quantile,
@@ -485,9 +497,7 @@ class UKIndexMultipleDeprivationQuantileView(APIView):
                     response = Response({"result": data})
                 elif lsoa_object["country"] == "Wales":
                     lsoa = LSOA.objects.filter(lsoa_code=lsoa_code).get()
-                    imd = WelshIndexMultipleDeprivation.objects.filter(
-                        lsoa=lsoa
-                    ).get()
+                    imd = WelshIndexMultipleDeprivation.objects.filter(lsoa=lsoa).get()
                     data = quantile_for_rank(
                         rank=imd.imd_rank,
                         requested_quantile=requested_quantile,
@@ -496,9 +506,7 @@ class UKIndexMultipleDeprivationQuantileView(APIView):
                     response = Response({"result": data})
                 elif lsoa_object["country"] == "Scotland":
                     lsoa = DataZone.objects.filter(data_zone_code=lsoa_code).get()
-                    imd = ScottishIndexMultipleDeprivation.objects.filter(
-                        data_zone=lsoa
-                    ).get()
+                    imd = ScottishIndexMultipleDeprivation.objects.filter(data_zone=lsoa).get()
                     data = quantile_for_rank(
                         rank=imd.imd_rank,
                         requested_quantile=requested_quantile,
@@ -507,9 +515,7 @@ class UKIndexMultipleDeprivationQuantileView(APIView):
                     response = Response({"result": data})
                 elif lsoa_object["country"] == "Northern Ireland":
                     lsoa = SOA.objects.filter(soa_code=lsoa_code).get()
-                    imd = NorthernIrelandIndexMultipleDeprivation.objects.filter(
-                        soa=lsoa
-                    ).get()
+                    imd = NorthernIrelandIndexMultipleDeprivation.objects.filter(soa=lsoa).get()
                     data = quantile_for_rank(
                         rank=imd.imd_rank,
                         requested_quantile=requested_quantile,

--- a/deprivation_scores/views.py
+++ b/deprivation_scores/views.py
@@ -353,7 +353,8 @@ class UKIndexMultipleDeprivationView(APIView):
         """
         post_code = self.request.query_params.get("postcode", None)
         if post_code:
-            lsoa_object = lsoa_for_postcode(postcode=post_code)
+            if not (lsoa_object := lsoa_for_postcode(postcode=post_code)):
+                raise ParseError("Invalid postcode supplied.", code=400)
 
             if lsoa_object["lsoa"]:
                 lsoa_code = lsoa_object["lsoa"]


### PR DESCRIPTION
Signed-off-by: anchit-chandran <anchit97123@gmail.com>

### Overview

Discovered through trying to find postcodes for each IMD in NPDA development, the endpoint:

```
http://localhost:8001/index_of_multiple_deprivation_quantile?postcode=SW11AA&quantile=5
```

Will lead to a runtime error if `postcode` is invalid. The `lsoa_for_postcode` fn returns None if the response is `404`. Therefore, if None returned, raise `ParseError`.

Tested working by making a request via swagger ui locally

Fixes #26 
The other thing is that I saw this because django debug mode is True in prod, should probably also be turned off?

Similarly, also signpost and attempt fallback to terminated_postcodes endpoint, e.g. for postcode `TS101QR`. In this case, the API returns 410 (GONE) with:

```
{
  "postcode": "TS10 1QR",
  "year_terminated": 2010,
  "month_terminated": 7,
  "longitude": -1.079159,
  "latitude": 54.615911
}
```