### PR TITLE
expose lsoa and lad names and lad boundaries

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# .githooks/pre-push
+#
+# Runs the uk_master tile table tests before pushing.
+# If the tile tables don't exist locally (i.e. process_geometries hasn't been
+# run), prints a reminder and allows the push to proceed.
+# If the tables exist and the tests fail, the push is blocked.
+#
+# One-time setup per developer:
+#   git config core.hooksPath .githooks
+
+set -euo pipefail
+
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+TEST_FILE="tests/test_uk_master_local_authority_fields.py"
+
+echo ""
+echo "==> pre-push: checking uk_master tile table tests..."
+
+# Work out how to invoke pytest (mirrors s/test logic)
+if [ -f "/.dockerenv" ]; then
+    RUN_PYTEST="python -m pytest"
+elif docker compose ps web 2>/dev/null | grep -q "running"; then
+    RUN_PYTEST="docker compose exec -T web python -m pytest"
+else
+    RUN_PYTEST="python -m pytest"
+fi
+
+# Run with -v so skip/pass/fail is visible; capture exit code without set -e
+set +e
+$RUN_PYTEST "$TEST_FILE" -v --tb=short 2>&1
+EXIT_CODE=$?
+set -e
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo -e "${GREEN}==> pre-push: tile table tests passed.${RESET}"
+    exit 0
+fi
+
+# pytest exit code 5 means "no tests collected" (all skipped counts as 0 collected)
+# exit code 0 with skips still exits 0 — if we get here, something failed.
+
+# Check whether the skip was the reason (tables absent) — re-run quietly to inspect
+SKIP_CHECK=$($RUN_PYTEST "$TEST_FILE" --co -q 2>&1 || true)
+if echo "$SKIP_CHECK" | grep -q "skipped"; then
+    echo ""
+    echo -e "${YELLOW}==> pre-push: tile table tests were skipped (uk_master tables not found).${RESET}"
+    echo -e "${YELLOW}    To validate LA metadata in tiles, run:${RESET}"
+    echo -e "${YELLOW}      python manage.py seed --mode process_geometries${RESET}"
+    echo -e "${YELLOW}    then push again. Allowing push to proceed.${RESET}"
+    echo ""
+    exit 0
+fi
+
+echo ""
+echo -e "${RED}==> pre-push: tile table tests FAILED. Fix the failures before pushing.${RESET}"
+echo ""
+exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,19 @@ Primary helper scripts:
 - `s/wait-for-db.sh`
   - Waits for DB readiness; optionally waits for seeded/populated tables when `WAIT_FOR_POPULATION=true`.
 
+## Git hooks (one-time setup)
+
+A pre-push hook lives in `.githooks/pre-push`. Activate it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+What it does on every `git push`:
+
+- If `uk_master_*` tile tables exist locally → runs `tests/test_uk_master_local_authority_fields.py` and **blocks the push on failure**.
+- If tables are absent (i.e. `process_geometries` has not been run) → prints a reminder and **allows the push**, matching CI behaviour (tests are skipped there too).
+
 Database dump/release workflow helpers:
 
 - `s/build-dump`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,24 @@ Materialized table families:
   - `public.lsoa_tiles_2021_z5_7`
   - `public.lsoa_tiles_2021_z8_10`
 
+## Dataset/Boundary Source Of Truth
+
+To avoid doc drift, treat `site/docs/boundaries.md` as the canonical source for:
+
+- Boundary dataset endpoints and code mappings
+- Boundary year vs IMD year behaviour
+- Tile property contracts exposed by pg_tileserv
+
+Current map behaviour summary (quick reference only):
+
+| View | England | Wales | Scotland | N. Ireland |
+| --- | --- | --- | --- | --- |
+| All UK | 2011 LSOA + 2019 IMD | 2011 LSOA + 2019 WIMD | 2011 DataZone + 2020 SIMD | 2001 SOA + 2017 NIMDM |
+| England-only (era toggle = 2021) | 2021 LSOA + 2025 IMD | n/a | n/a | n/a |
+| England-only (era toggle = 2011) | 2011 LSOA + 2019 IMD | n/a | n/a | n/a |
+
+If this summary conflicts with `site/docs/boundaries.md`, update this section to match `site/docs/boundaries.md`.
+
 ## Exposed tile properties
 
 As of current implementation:
@@ -67,6 +85,9 @@ As of current implementation:
 - `public.uk_master_*` properties include:
   - `code`
   - `area_name`
+  - `la_code` (England/Wales/Scotland; `NULL` for N. Ireland)
+  - `la_name` (England/Wales/Scotland; `NULL` for N. Ireland)
+  - `la_year` (England/Wales/Scotland; `NULL` for N. Ireland)
   - `imd_decile`
   - `imd_year`
   - `nation`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,38 @@ Misc:
 - `s/get-build-info`
   - Outputs current git hash and branch JSON.
 
+## Publishing and deployment docs
+
+For full operator guidance, use these docs in `site/docs/`:
+
+- `site/docs/database-dump-and-publish.md`
+  - Local dump build/test and GitHub Release publication (including chunk splitting for large dumps).
+- `site/docs/managed-database-seeding.md`
+  - Restoring a release dump into Azure Database for PostgreSQL (typically from Azure Container Apps via `s/restore-db`).
+- `site/docs/deploy.md`
+  - End-to-end deployment architecture and sequence (dump publication, DB seed/restore, app deploy, verification).
+
+If these docs and this file disagree, treat `site/docs/*.md` as the source of truth and update this summary.
+
+## Recommended release/deploy workflow (high-level)
+
+For this project's large database footprint, the intended workflow is:
+
+1. Build and test the seeded database dump locally (`s/build-dump`).
+2. Publish the dump to GitHub Releases (`s/release-dump`), with automatic split parts for large artifacts.
+3. In Azure, restore that released dump into the managed PostgreSQL instance (`s/restore-db`, usually executed from the web container).
+4. Deploy/update application containers (Django/nginx/pg_tileserv) separately.
+
+Why this is preferred:
+
+- Keeps heavy seed/build work local and reproducible.
+- Uses versioned release artifacts for rollback and auditability.
+- Decouples data lifecycle from app container rollout.
+
+Practical note:
+
+- App deployment does not seed the managed database automatically; restore/seed is a separate operator step.
+
 ## Agent implementation notes
 
 - For map property changes, prioritize `seed.py` post-processing SQL over frontend workarounds.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,8 @@ Primary helper scripts:
   - Runs `makemigrations` then `migrate`.
 - `s/pg-tiles`
   - Starts pg_tileserv service via compose.
+- `s/test`
+  - Runs pytest with pass-through flags; uses running web container when available, otherwise starts a one-off test container.
 - `s/wait-for-db.sh`
   - Waits for DB readiness; optionally waits for seeded/populated tables when `WAIT_FOR_POPULATION=true`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,173 @@
+# AGENTS.md
+
+This file is a quick operational guide for coding agents and LLM tools working in this repository. It complements, not replaces, the full project docs under site/docs/.
+
+## Project at a glance
+
+- Stack: Django + PostGIS + pg_tileserv + optional nginx in deployment.
+- Core purpose: seed UK deprivation and boundary datasets, then serve fast vector tiles for map rendering.
+- Key seeding command: `python manage.py seed --mode <mode>`.
+
+## Data pipeline summary
+
+The platform has two distinct data phases:
+
+1. Base data seeding (tabular and relational data)
+
+- Populates:
+  - Organisational geography references (LSOA/DataZone/SOA/LocalAuthority)
+  - IMD datasets by nation and year
+  - Supplementary scores/ranks and population density data
+
+- Typical modes include:
+  - `__all__`
+  - `add_organisational_areas`
+  - `add_english_imds`
+  - `add_welsh_imds`
+  - `add_scottish_imds`
+  - `add_northern_ireland_imds`
+  - `add_population_densities`
+  - `ci_test`
+
+1. Boundary enrichment + spatial post-processing
+
+- `import_bfc_boundaries` downloads/streams external geometry datasets and merges geometries into base tables.
+- `_run_post_processing_sql()` then:
+  - Creates 3857 geometry columns
+  - Generates simplified geometries for low/medium zoom
+  - Builds spatial indexes and clusters
+  - Materializes tile-serving tables for all zoom tiers
+- `process_geometries` runs post-processing only (no boundary re-download), useful for SQL/view/table-shape changes.
+
+## Tile-serving model
+
+Tiles are served directly from PostGIS by pg_tileserv. There is no Django serialization path for map tiles.
+
+Materialized table families:
+
+- UK mixed-nation tables:
+  - `public.uk_master_2011_z0_4`
+  - `public.uk_master_2011_z5_7`
+  - `public.uk_master_2011_z8_10`
+  - `public.uk_master_2021_z0_4`
+  - `public.uk_master_2021_z5_7`
+  - `public.uk_master_2021_z8_10`
+- LSOA-focused tables:
+  - `public.lsoa_tiles_2011_z0_4`
+  - `public.lsoa_tiles_2011_z5_7`
+  - `public.lsoa_tiles_2011_z8_10`
+  - `public.lsoa_tiles_2021_z0_4`
+  - `public.lsoa_tiles_2021_z5_7`
+  - `public.lsoa_tiles_2021_z8_10`
+
+## Exposed tile properties
+
+As of current implementation:
+
+- `public.uk_master_*` properties include:
+  - `code`
+  - `area_name`
+  - `imd_decile`
+  - `imd_year`
+  - `nation`
+  - `year`
+- `public.lsoa_tiles_*` properties include:
+  - `lsoa_code`
+  - `area_name`
+  - `imd_decile`
+  - `imd_rank`
+  - `year`
+
+If you need to expose additional tile attributes, update SQL in `deprivation_scores/management/commands/seed.py` helper methods and rerun `--mode process_geometries`.
+
+## When reseeding is required vs not required
+
+No full reseed required:
+
+- Adding/removing columns in tile materialization SQL
+- Adjusting simplification thresholds/indexing in post-processing SQL
+- Refreshing tile output shape from existing seeded data
+
+Use:
+
+- `python manage.py seed --mode process_geometries`
+
+Full/base reseed likely required:
+
+- New source CSV content for core IMD/reference tables
+- New boundary source ingestion requirements that rely on raw geometry re-import
+- Fresh environment bootstrap from empty database
+
+Use:
+
+- `python manage.py seed --mode __all__`
+- then `python manage.py seed --mode import_bfc_boundaries`
+
+## Convenience scripts in s/
+
+Primary helper scripts:
+
+- `s/dev`
+  - Starts the PostGIS development compose stack.
+- `s/runserver`
+  - Runs Django dev server.
+- `s/migrate`
+  - Runs `makemigrations` then `migrate`.
+- `s/pg-tiles`
+  - Starts pg_tileserv service via compose.
+- `s/wait-for-db.sh`
+  - Waits for DB readiness; optionally waits for seeded/populated tables when `WAIT_FOR_POPULATION=true`.
+
+Database dump/release workflow helpers:
+
+- `s/build-dump`
+  - Creates a local PostGIS container, runs migrations and seed modes, builds a compressed pg_dump, and performs a restore test.
+- `s/release-dump`
+  - Publishes dump artifacts to GitHub Releases; auto-splits large dumps.
+- `s/restore-db`
+  - Restores release dump into managed PostgreSQL (with safety guard and extension handling).
+- `s/deploy-db`
+  - Operator notes/steps for running restore in Azure Container Apps context.
+
+Misc:
+
+- `s/get-build-info`
+  - Outputs current git hash and branch JSON.
+
+## Agent implementation notes
+
+- For map property changes, prioritize `seed.py` post-processing SQL over frontend workarounds.
+- Keep output column aliases stable (`code`, `nation`, `imd_decile`, etc.) to avoid breaking map clients.
+- For nation-agnostic labels in UI, use `area_name` rather than assuming LSOA naming across all nations.
+- After SQL changes, validate with pg_tileserv metadata endpoint:
+  - `/tiles/public.uk_master_2021_z8_10.json`
+  - `/tiles/public.lsoa_tiles_2021_z8_10.json`
+
+## Debugging tile property issues
+
+If a new property appears correctly in the pg_tileserv metadata JSON but the frontend shows a fallback value (e.g. "Unknown area"), follow this checklist:
+
+1. **Confirm DB data is populated** — run SQL against the source tables to check for nulls:
+
+   ```sql
+   SELECT COUNT(*) FILTER (WHERE area_name IS NULL) FROM public.uk_master_2021_z8_10;
+   SELECT COUNT(*) FILTER (WHERE trim(area_name) = '') FROM public.uk_master_2021_z8_10;
+   ```
+
+2. **Confirm tile tables have been rebuilt** — run `process_geometries` after any SQL change:
+
+   ```bash
+   python manage.py seed --mode process_geometries
+   ```
+
+3. **Confirm pg_tileserv reports the property** — the metadata endpoint is authoritative:
+
+   ```bash
+   curl http://localhost:7800/public.uk_master_2021_z8_10.json | jq '.properties[] | .name'
+   ```
+
+4. **Inspect actual runtime keys** — `map-logic.js` logs the exact property keys and a sample object to the browser console on first hover. Open DevTools and hover an area to confirm what MapLibre is receiving.
+
+5. **Check the JS lookup order** — `getPropCaseInsensitive()` in `site/map-logic.js` tries keys in order. Ensure the canonical alias (e.g. `area_name`) is the first candidate.
+
+In a confirmed case: tile schema, DB data, and pg_tileserv metadata were all correct. The root cause was that `feature.properties` lookup was strict and brittle. Adding `getPropCaseInsensitive()` with an ordered candidate list resolved the issue.

--- a/deprivation_scores/management/commands/seed.py
+++ b/deprivation_scores/management/commands/seed.py
@@ -113,6 +113,7 @@ class Command(BaseCommand):
                 l.year::int as year,
                 l.{geom_column}::geometry(MultiPolygon, 3857) AS geom,
                 l.lsoa_code::text,
+                l.lsoa_name::text AS area_name,
                 COALESCE(e.imd_decile, w.imd_decile, 0)::int as imd_decile,
                 COALESCE(e.imd_rank, w.imd_rank, 0)::int as imd_rank
             FROM deprivation_scores_lsoa l
@@ -168,6 +169,7 @@ class Command(BaseCommand):
                 l.year::int AS year, 
                 {imd_year}::int AS imd_year, 
                 l.lsoa_code::text AS code, 
+                l.lsoa_name::text AS area_name,
                 ST_MakeValid(ST_Multi(l.{actual_geom_col}))::geometry(MultiPolygon, 3857) AS geom, 
                 'england'::text AS nation,
                 COALESCE(e.imd_decile, 0)::int AS imd_decile
@@ -185,6 +187,7 @@ class Command(BaseCommand):
                 l.year::int AS year, 
                 {wales_imd_year}::int AS imd_year, 
                 l.lsoa_code::text AS code, 
+                l.lsoa_name::text AS area_name,
                 ST_MakeValid(ST_Multi(l.{actual_geom_col}))::geometry(MultiPolygon, 3857) AS geom, 
                 'wales'::text AS nation,
                 COALESCE(w.imd_decile, 0)::int AS imd_decile
@@ -202,6 +205,7 @@ class Command(BaseCommand):
                 d.year::int AS year, 
                 {scotland_imd_year}::int AS imd_year, 
                 d.data_zone_code::text AS code, 
+                d.data_zone_name::text AS area_name,
                 ST_MakeValid(ST_Multi(d.{actual_geom_col}))::geometry(MultiPolygon, 3857) AS geom, 
                 'scotland'::text AS nation,
                 COALESCE(WIDTH_BUCKET(s.imd_rank, 1, 6977, 10), 0)::int AS imd_decile
@@ -218,6 +222,7 @@ class Command(BaseCommand):
                 so.year::int AS year, 
                 {ni_imd_year}::int AS imd_year, 
                 so.soa_code::text AS code, 
+                so.soa_name::text AS area_name,
                 ST_MakeValid(ST_Multi(so.{actual_geom_col}))::geometry(MultiPolygon, 3857) AS geom, 
                 'northern_ireland'::text AS nation,
                 COALESCE(WIDTH_BUCKET(ni.imd_rank, 1, 891, 10), 0)::int AS imd_decile

--- a/deprivation_scores/management/commands/seed.py
+++ b/deprivation_scores/management/commands/seed.py
@@ -170,12 +170,17 @@ class Command(BaseCommand):
                 {imd_year}::int AS imd_year, 
                 l.lsoa_code::text AS code, 
                 l.lsoa_name::text AS area_name,
+                la.local_authority_district_code::text AS la_code,
+                la.local_authority_district_name::text AS la_name,
+                la.year::int AS la_year,
                 ST_MakeValid(ST_Multi(l.{actual_geom_col}))::geometry(MultiPolygon, 3857) AS geom, 
                 'england'::text AS nation,
                 COALESCE(e.imd_decile, 0)::int AS imd_decile
             FROM deprivation_scores_lsoa l
             LEFT JOIN deprivation_scores_englishindexmultipledeprivation e 
                 ON e.lsoa_id = l.id AND e.year = {imd_year}
+            LEFT JOIN deprivation_scores_localauthority la
+                ON la.id = l.local_authority_district_id
             WHERE l.lsoa_code LIKE 'E%' 
                 AND l.{actual_geom_col} IS NOT NULL 
                 AND l.year = {boundary_year}
@@ -188,12 +193,17 @@ class Command(BaseCommand):
                 {wales_imd_year}::int AS imd_year, 
                 l.lsoa_code::text AS code, 
                 l.lsoa_name::text AS area_name,
+                la.local_authority_district_code::text AS la_code,
+                la.local_authority_district_name::text AS la_name,
+                la.year::int AS la_year,
                 ST_MakeValid(ST_Multi(l.{actual_geom_col}))::geometry(MultiPolygon, 3857) AS geom, 
                 'wales'::text AS nation,
                 COALESCE(w.imd_decile, 0)::int AS imd_decile
             FROM deprivation_scores_lsoa l
             LEFT JOIN deprivation_scores_welshindexmultipledeprivation w 
                 ON w.lsoa_id = l.id AND w.year = {wales_imd_year}
+            LEFT JOIN deprivation_scores_localauthority la
+                ON la.id = l.local_authority_district_id
             WHERE l.lsoa_code LIKE 'W%' 
                 AND l.{actual_geom_col} IS NOT NULL 
                 AND l.year = {boundary_year}
@@ -206,12 +216,17 @@ class Command(BaseCommand):
                 {scotland_imd_year}::int AS imd_year, 
                 d.data_zone_code::text AS code, 
                 d.data_zone_name::text AS area_name,
+                la.local_authority_district_code::text AS la_code,
+                la.local_authority_district_name::text AS la_name,
+                la.year::int AS la_year,
                 ST_MakeValid(ST_Multi(d.{actual_geom_col}))::geometry(MultiPolygon, 3857) AS geom, 
                 'scotland'::text AS nation,
                 COALESCE(WIDTH_BUCKET(s.imd_rank, 1, 6977, 10), 0)::int AS imd_decile
             FROM deprivation_scores_datazone d
             LEFT JOIN deprivation_scores_scottishindexmultipledeprivation s 
                 ON s.data_zone_id = d.id AND s.year = {scotland_imd_year}
+            LEFT JOIN deprivation_scores_localauthority la
+                ON la.id = d.local_authority_id
             WHERE d.{actual_geom_col} IS NOT NULL 
                 AND d.year = {scotland_boundary_year}
 
@@ -223,6 +238,9 @@ class Command(BaseCommand):
                 {ni_imd_year}::int AS imd_year, 
                 so.soa_code::text AS code, 
                 so.soa_name::text AS area_name,
+                NULL::text AS la_code,
+                NULL::text AS la_name,
+                NULL::int AS la_year,
                 ST_MakeValid(ST_Multi(so.{actual_geom_col}))::geometry(MultiPolygon, 3857) AS geom, 
                 'northern_ireland'::text AS nation,
                 COALESCE(WIDTH_BUCKET(ni.imd_rank, 1, 891, 10), 0)::int AS imd_decile

--- a/s/test
+++ b/s/test
@@ -1,0 +1,44 @@
+#!/bin/bash -e
+
+# Convenience script: run pytest either locally or via docker compose web container.
+# Usage examples:
+#   ./s/test
+#   ./s/test -q tests/test_uk_master_local_authority_fields.py
+
+COMPOSE_FILE="docker-compose-postgis.yml"
+
+run_local() {
+  echo "✨ Running pytest locally"
+  pytest "$@"
+}
+
+run_in_web_exec() {
+  echo "✨ Running pytest in running web container"
+  docker compose -f "$COMPOSE_FILE" exec -T web pytest "$@"
+}
+
+run_in_web_run() {
+  echo "✨ Running pytest in one-off web container"
+  mkdir -p datadb
+  docker compose -f "$COMPOSE_FILE" up -d db
+  docker compose -f "$COMPOSE_FILE" run --rm web pytest "$@"
+}
+
+# If already inside a container, run directly.
+if [[ -f "/.dockerenv" ]]; then
+  run_local "$@"
+  exit 0
+fi
+
+# If docker compose is unavailable, fallback to local pytest.
+if ! command -v docker >/dev/null 2>&1; then
+  run_local "$@"
+  exit 0
+fi
+
+# Prefer using an already-running web container.
+if docker compose -f "$COMPOSE_FILE" ps --status running --services 2>/dev/null | grep -qx "web"; then
+  run_in_web_exec "$@"
+else
+  run_in_web_run "$@"
+fi

--- a/site/docs/boundaries.md
+++ b/site/docs/boundaries.md
@@ -33,7 +33,7 @@ We use **BFC (Boundaries Full Clipped)** datasets to ensure high-fidelity bounda
 
 ## Technical Note: Why we use Streaming over ogr2ogr
 
-While `ogr2ogr` is a standard tool for spatial data migration, this project utilizes a custom Python streaming implementation via `requests` and `GeoPandas`. This approach was chosen to handle the **ArcGIS resultRecordCount** limits more gracefully and to avoid external binary dependencies in the web container. 
+While `ogr2ogr` is a standard tool for spatial data migration, this project utilizes a custom Python streaming implementation via `requests` and `GeoPandas`. This approach was chosen to handle the **ArcGIS resultRecordCount** limits more gracefully and to avoid external binary dependencies in the web container.
 
 The **2024 Local Authority** endpoint, in particular, is sensitive to large requests; therefore, we implement a strict `chunk_size` (e.g., 100 records) to prevent timeout errors and 500-responses from the ArcGIS server. This streaming method ensures that we only move the necessary identifier and geometry fields into the database, keeping memory usage predictable during the enrichment process.
 
@@ -43,10 +43,63 @@ To achieve fast rendering on the frontend:
 
 1. **pg_tileserv**: A dedicated Go-based container connects to the database and serves the SQL views as **MVT (Mapbox Vector Tiles)**.
 2. **Resolution Switching**: The frontend automatically requests different views based on zoom level:
-    * `z0-z4`: Uses `uk_master_tiles_z0_4` (High simplification).
-    * `z5-z7`: Uses `uk_master_tiles_z5_7` (Medium simplification).
-    * `z8+`: Uses `uk_master_tiles_z8_10` (Full detail BFC).
+    * `z0-z4`: Uses `public.uk_master_<era>_z0_4` (high simplification).
+    * `z5-z7`: Uses `public.uk_master_<era>_z5_7` (medium simplification).
+    * `z8+`: Uses `public.uk_master_<era>_z8_10` (full detail BFC).
+    * `<era>` is either `2011` (IMD 2019 England / 2019 Wales) or `2021` (IMD 2025 England / 2019 Wales).
 3. **CDN**: Tiles are cached at the edge via a CDN to ensure sub-second map interactivity.
+
+## Tile Properties Exposed
+
+The post-processing SQL materializes tile-serving tables and explicitly controls the attributes exposed by pg_tileserv.
+
+### UK Master Tables (`public.uk_master_*`)
+
+The following properties are exposed at all zoom levels:
+
+* `code`: Area code (`lsoa_code`, `data_zone_code`, or `soa_code`)
+* `area_name`: Human-readable name (`lsoa_name`, `data_zone_name`, or `soa_name`)
+* `imd_decile`: Decile used for choropleth colouring
+* `imd_year`: IMD publication year for that nation in the selected era
+* `nation`: `england`, `wales`, `scotland`, or `northern_ireland`
+* `year`: Boundary year
+
+### LSOA-only Tables (`public.lsoa_tiles_*`)
+
+The following properties are exposed at all zoom levels:
+
+* `lsoa_code`
+* `area_name` (from `lsoa_name`)
+* `imd_decile`
+* `imd_rank`
+* `year`
+
+### Why this matters
+
+Because pg_tileserv serves directly from these materialized tables, adding a column in the post-processing SQL makes it available immediately in tile properties after rebuilding the tables.
+
+### Verifying exposed properties
+
+Confirm what is actually served by querying the pg_tileserv metadata endpoints directly:
+
+```bash
+curl http://localhost:7800/public.uk_master_2021_z8_10.json | jq '.properties[] | .name'
+curl http://localhost:7800/public.lsoa_tiles_2021_z8_10.json | jq '.properties[] | .name'
+```
+
+This is the authoritative source of truth for what the frontend receives. If a property appears in the SQL `SELECT` but not in these metadata responses, the tile tables have not been rebuilt yet.
+
+### Frontend property lookup robustness
+
+MapLibre GL JS decodes MVT properties and surfaces them as a plain JavaScript object on `feature.properties`. Property key casing is preserved from the PostGIS column name, so consistent snake_case aliases in the SQL (e.g. `area_name`, `imd_decile`) are important.
+
+`map-logic.js` uses a `getPropCaseInsensitive()` helper that tries an ordered list of candidate keys and falls back to a case-insensitive scan of the property object. This guards against silent lookup failures if aliases change. When adding new tile properties, add the canonical key as the first candidate in the relevant `getPropCaseInsensitive()` call in `site/map-logic.js`.
+
+On first hover the map logs the following to the browser console to assist debugging:
+
+* Tile base URL
+* Exact property keys received from the tile
+* A sample properties object
 
 ## How to Run
 
@@ -58,8 +111,14 @@ python manage.py seed --mode import_bfc_boundaries
 
 To update or overwrite existing geometries, use the `--force` flag.
 
+If you only changed exposed tile properties (for example adding `area_name`), you can rebuild just the post-processed tile tables without re-downloading boundaries:
+
+```bash
+python manage.py seed --mode process_geometries
+```
+
 ## References
 
-PostGIS Reference: https://postgis.net/docs/
-ONS Geoportal: https://geoportal.statistics.gov.uk/
-pg_tileserv: https://github.com/CrunchyData/pg_tileserv
+* PostGIS Reference: <https://postgis.net/docs/>
+* ONS Geoportal: <https://geoportal.statistics.gov.uk/>
+* pg_tileserv: <https://github.com/CrunchyData/pg_tileserv>

--- a/site/docs/boundaries.md
+++ b/site/docs/boundaries.md
@@ -53,14 +53,18 @@ To achieve fast rendering on the frontend:
 
 This section summarizes what the map currently renders by view. Use this as the quick reference for boundary year, IMD year, and local authority metadata in tile properties.
 
-| View | Nation | Boundary Type/Year (`year`) | IMD Dataset/Year (`imd_year`) | Local Authority in Tiles |
-| :--- | :--- | :--- | :--- | :--- |
-| All UK (`uk_master_2011_*`) | England | LSOA 2011 | IMD 2019 | LAD code/name/year from 2019 LA table |
-| All UK (`uk_master_2011_*`) | Wales | LSOA 2011 | WIMD 2019 | LAD code/name/year from 2019 LA table |
-| All UK (`uk_master_2011_*`) | Scotland | DataZone 2011 | SIMD 2020 | LA code/name/year from 2011 Scotland-linked LA table |
-| All UK (`uk_master_2011_*`) | Northern Ireland | SOA 2001 | NIMDM 2017 | `la_code`/`la_name`/`la_year` are `NULL` |
-| England-only (era = 2011) | England | LSOA 2011 | IMD 2019 | LAD code/name/year from 2019 LA table |
-| England-only (era = 2021) | England | LSOA 2021 | IMD 2025 | LAD code/name/year from 2024 LA table |
+| View | Nation | Boundary Type/Year (`year`) | IMD Dataset/Year (`imd_year`) | LA/LAD metadata year (`la_year`) | Match note |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| All UK (`uk_master_2011_*`) | England | LSOA 2011 | IMD 2019 | 2019 | Lookup-linked (2011 LSOAs reference 2019 LADs in source lookup file) |
+| All UK (`uk_master_2011_*`) | Wales | LSOA 2011 | WIMD 2019 | 2019 | Lookup-linked (2011 LSOAs reference 2019 LADs in source lookup file) |
+| All UK (`uk_master_2011_*`) | Scotland | DataZone 2011 | SIMD 2020 | 2011 | Lookup-linked (2011 DataZones reference 2011 LAs) |
+| All UK (`uk_master_2011_*`) | Northern Ireland | SOA 2001 | NIMDM 2017 | `NULL` | Not applicable in current layer (`la_*` fields are `NULL`) |
+| England-only (era = 2011) | England | LSOA 2011 | IMD 2019 | 2019 | Lookup-linked (2011 LSOAs reference 2019 LADs in source lookup file) |
+| England-only (era = 2021) | England | LSOA 2021 | IMD 2025 | 2024 | Lookup-linked (2021 LSOAs reference 2024 LADs in source lookup file) |
+
+### Important alignment caveat
+
+`la_*` fields are currently joined by the pre-seeded lookup relationships (LSOA/DataZone -> LocalAuthority), not by spatial overlay/intersection at runtime. This means they represent the mapped administrative relationship in the source datasets, not a geometric "best fit" recomputation inside tile SQL.
 
 ### Northern Ireland note
 

--- a/site/docs/boundaries.md
+++ b/site/docs/boundaries.md
@@ -49,6 +49,23 @@ To achieve fast rendering on the frontend:
     * `<era>` is either `2011` (IMD 2019 England / 2019 Wales) or `2021` (IMD 2025 England / 2019 Wales).
 3. **CDN**: Tiles are cached at the edge via a CDN to ensure sub-second map interactivity.
 
+## Current Dataset Mapping (Map Behaviour)
+
+This section summarizes what the map currently renders by view. Use this as the quick reference for boundary year, IMD year, and local authority metadata in tile properties.
+
+| View | Nation | Boundary Type/Year (`year`) | IMD Dataset/Year (`imd_year`) | Local Authority in Tiles |
+| :--- | :--- | :--- | :--- | :--- |
+| All UK (`uk_master_2011_*`) | England | LSOA 2011 | IMD 2019 | LAD code/name/year from 2019 LA table |
+| All UK (`uk_master_2011_*`) | Wales | LSOA 2011 | WIMD 2019 | LAD code/name/year from 2019 LA table |
+| All UK (`uk_master_2011_*`) | Scotland | DataZone 2011 | SIMD 2020 | LA code/name/year from 2011 Scotland-linked LA table |
+| All UK (`uk_master_2011_*`) | Northern Ireland | SOA 2001 | NIMDM 2017 | `la_code`/`la_name`/`la_year` are `NULL` |
+| England-only (era = 2011) | England | LSOA 2011 | IMD 2019 | LAD code/name/year from 2019 LA table |
+| England-only (era = 2021) | England | LSOA 2021 | IMD 2025 | LAD code/name/year from 2024 LA table |
+
+### Northern Ireland note
+
+Northern Ireland does not use the same Local Authority District model as England/Wales/Scotland in this dataset. Tooltips should treat `la_*` fields as not applicable for NI and can show a message such as: "Northern Ireland uses Local Government Districts, not LAD fields in this layer."
+
 ## Tile Properties Exposed
 
 The post-processing SQL materializes tile-serving tables and explicitly controls the attributes exposed by pg_tileserv.
@@ -59,6 +76,9 @@ The following properties are exposed at all zoom levels:
 
 * `code`: Area code (`lsoa_code`, `data_zone_code`, or `soa_code`)
 * `area_name`: Human-readable name (`lsoa_name`, `data_zone_name`, or `soa_name`)
+* `la_code`: Local authority code for England/Wales/Scotland (`NULL` for Northern Ireland)
+* `la_name`: Local authority name for England/Wales/Scotland (`NULL` for Northern Ireland)
+* `la_year`: Local authority reference year for England/Wales/Scotland (`NULL` for Northern Ireland)
 * `imd_decile`: Decile used for choropleth colouring
 * `imd_year`: IMD publication year for that nation in the selected era
 * `nation`: `england`, `wales`, `scotland`, or `northern_ireland`

--- a/site/index.html
+++ b/site/index.html
@@ -169,13 +169,16 @@
 <div class="control-panel">
     <h2 style="margin-top:0; font-size: 1.2rem; color: #0d0d58; margin-bottom: 20px;">Map Controls</h2>
     
-    <div class="control-group">
-        <label class="control-label" for="era-toggle">Data Era & Boundaries</label>
+    <div class="control-group" id="era-toggle-group">
+        <label class="control-label" for="era-toggle">England IMD Year</label>
         <select id="era-toggle" class="select select-bordered w-full select-sm">
-            <option value="2021" selected>2025 IMD (2021 LSOAs)</option>
-            <option value="2011">2019 IMD (2011 LSOAs)</option>
+            <option value="2021" selected>2025 IMD &middot; 2021 LSOAs</option>
+            <option value="2011">2019 IMD &middot; 2011 LSOAs</option>
         </select>
+        <div id="era-note" style="font-size:0.7rem;color:#888;margin-top:4px;min-height:1em;"></div>
     </div>
+
+    <div id="dataset-info" style="font-size:0.72rem;color:#444;background:#f0f4f8;border-radius:6px;padding:8px 10px;margin-bottom:12px;line-height:1.7;border-left:3px solid #11a7f2;"></div>
 
     <div class="control-group">
         <label class="control-label" for="nation-filter">Filter Nation</label>

--- a/site/index.html
+++ b/site/index.html
@@ -190,6 +190,15 @@
             <option value="northern_ireland">Northern Ireland</option>
         </select>
     </div>
+
+    <div class="control-group" id="la-toggle-group">
+        <label class="control-label" for="la-toggle">Boundary Overlay</label>
+        <label style="display:flex;align-items:center;gap:8px;font-size:0.82rem;color:#333;cursor:pointer;">
+            <input id="la-toggle" type="checkbox" style="accent-color:#0d0d58;">
+            Show Local Authority boundaries
+        </label>
+        <div id="la-note" style="font-size:0.7rem;color:#888;margin-top:4px;min-height:1em;"></div>
+    </div>
 </div>
 
 <!-- Legend (content will be populated dynamically) -->

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -89,6 +89,10 @@ const DATASET_INFO = {
 let currentEra = "2021";
 let currentNation = "all";
 
+const LA_SOURCE_ID = "la-boundaries-source";
+const LA_LAYER_ID = "la-boundaries-layer";
+const LA_SOURCE_LAYER = "public.la_tiles";
+
 // Returns the tile era to actually request for the given nation selection.
 // Only England solo respects the era toggle; everything else uses 2011.
 function effectiveEra(nation) {
@@ -98,6 +102,155 @@ function effectiveEra(nation) {
 function getViewName(era, zoom) {
   const zoomSuffix = zoom <= 4 ? "z0_4" : zoom <= 7 ? "z5_7" : "z8_10";
   return `public.uk_master_${era}_${zoomSuffix}`;
+}
+
+function getLocalAuthorityYearForNation(nation) {
+  if (nation === "england") {
+    return currentNation === "england" && currentEra === "2021" ? 2024 : 2019;
+  }
+  if (nation === "wales") {
+    return 2019;
+  }
+  if (nation === "scotland") {
+    return 2011;
+  }
+  return null;
+}
+
+function getLocalAuthorityFilter() {
+  if (currentNation === "northern_ireland") {
+    return null;
+  }
+
+  if (currentNation === "england") {
+    return [
+      "all",
+      ["==", ["slice", ["get", "lad_code"], 0, 1], "E"],
+      ["==", ["get", "year"], getLocalAuthorityYearForNation("england")],
+    ];
+  }
+
+  if (currentNation === "wales") {
+    return [
+      "all",
+      ["==", ["slice", ["get", "lad_code"], 0, 1], "W"],
+      ["==", ["get", "year"], 2019],
+    ];
+  }
+
+  if (currentNation === "scotland") {
+    return [
+      "all",
+      ["==", ["slice", ["get", "lad_code"], 0, 1], "S"],
+      ["==", ["get", "year"], 2011],
+    ];
+  }
+
+  return [
+    "any",
+    [
+      "all",
+      ["==", ["slice", ["get", "lad_code"], 0, 1], "E"],
+      ["==", ["get", "year"], 2019],
+    ],
+    [
+      "all",
+      ["==", ["slice", ["get", "lad_code"], 0, 1], "W"],
+      ["==", ["get", "year"], 2019],
+    ],
+    [
+      "all",
+      ["==", ["slice", ["get", "lad_code"], 0, 1], "S"],
+      ["==", ["get", "year"], 2011],
+    ],
+  ];
+}
+
+function ensureLocalAuthoritySource() {
+  if (map.getSource(LA_SOURCE_ID)) {
+    return;
+  }
+
+  map.addSource(LA_SOURCE_ID, {
+    type: "vector",
+    tiles: [`${TILES_BASE_URL}/${LA_SOURCE_LAYER}/{z}/{x}/{y}.pbf`],
+    minzoom: 0,
+    maxzoom: 14,
+  });
+}
+
+function removeLocalAuthorityLayer() {
+  if (map.getLayer(LA_LAYER_ID)) {
+    map.removeLayer(LA_LAYER_ID);
+  }
+}
+
+function updateLocalAuthorityLayer() {
+  const laToggle = document.getElementById("la-toggle");
+  const requested = !!laToggle?.checked;
+
+  if (!requested || currentNation === "northern_ireland") {
+    removeLocalAuthorityLayer();
+    return;
+  }
+
+  ensureLocalAuthoritySource();
+
+  if (!map.getLayer(LA_LAYER_ID)) {
+    map.addLayer({
+      id: LA_LAYER_ID,
+      type: "line",
+      source: LA_SOURCE_ID,
+      "source-layer": LA_SOURCE_LAYER,
+      paint: {
+        "line-color": "rgba(55, 65, 81, 0.55)",
+        "line-width": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          4,
+          0.6,
+          7,
+          1.1,
+          10,
+          1.8,
+        ],
+        "line-opacity": 1,
+      },
+    });
+  }
+
+  // Keep LA boundaries above the deprivation fill layer after source/layer swaps.
+  map.moveLayer(LA_LAYER_ID);
+
+  const laFilter = getLocalAuthorityFilter();
+  if (laFilter) {
+    map.setFilter(LA_LAYER_ID, laFilter);
+  } else {
+    removeLocalAuthorityLayer();
+  }
+}
+
+function updateLocalAuthorityControlState() {
+  const laToggle = document.getElementById("la-toggle");
+  const laNote = document.getElementById("la-note");
+  const laGroup = document.getElementById("la-toggle-group");
+
+  const enabled = currentNation !== "northern_ireland";
+  laToggle.disabled = !enabled;
+  laGroup.style.opacity = enabled ? "1" : "0.45";
+
+  if (!enabled && laToggle.checked) {
+    laToggle.checked = false;
+  }
+
+  laNote.textContent = enabled
+    ? currentNation === "england" && currentEra === "2021"
+      ? "Using 2024 Local Authority boundaries"
+      : currentNation === "all"
+        ? "All UK: England/Wales 2019 + Scotland 2011 boundaries"
+        : "Showing matching Local Authority boundaries for this view"
+    : "Not available for Northern Ireland in this layer";
 }
 
 function getColorExpression() {
@@ -219,6 +372,8 @@ function updateMapSource() {
     map.setFilter("deprivation-layer", currentFilter);
   }
 
+  updateLocalAuthorityLayer();
+
   console.log(`Switched to table: ${newLayer}, tiles: ${newTiles[0]}`);
 }
 
@@ -245,6 +400,9 @@ map.on("load", () => {
   });
 
   map.on("zoomend", updateMapSource);
+
+  updateLocalAuthorityControlState();
+  updateLocalAuthorityLayer();
 
   const popup = new maplibregl.Popup({
     closeButton: false,
@@ -387,6 +545,8 @@ document.getElementById("era-toggle").addEventListener("change", (e) => {
   currentEra = e.target.value;
   updateMapSource();
   updateDatasetInfo(currentNation, currentEra);
+  updateLocalAuthorityControlState();
+  updateLocalAuthorityLayer();
 });
 
 document.getElementById("nation-filter").addEventListener("change", (e) => {
@@ -400,6 +560,12 @@ document.getElementById("nation-filter").addEventListener("change", (e) => {
   updateMapSource();
   updateLegend(selectedNation);
   updateDatasetInfo(selectedNation, currentEra);
+  updateLocalAuthorityControlState();
+  updateLocalAuthorityLayer();
+});
+
+document.getElementById("la-toggle").addEventListener("change", (e) => {
+  updateLocalAuthorityLayer();
 });
 
 function updateLegend(nation) {

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -276,6 +276,24 @@ map.on("load", () => {
         "soa_code",
       ]) || "Unknown code";
     const imdYear = getPropCaseInsensitive(props, ["imd_year", "year"]);
+    const localAuthorityCode = getPropCaseInsensitive(props, [
+      "la_code",
+      "lad_code",
+      "local_authority_code",
+      "local_authority_district_code",
+    ]);
+    const localAuthorityName = getPropCaseInsensitive(props, [
+      "la_name",
+      "lad_name",
+      "local_authority_name",
+      "local_authority_district_name",
+    ]);
+    const localAuthorityYear = getPropCaseInsensitive(props, [
+      "la_year",
+      "lad_year",
+      "local_authority_year",
+      "local_authority_district_year",
+    ]);
 
     const areaLabel = nation
       ? `${String(nation).replace(/_/g, " ").toUpperCase()}`
@@ -291,6 +309,14 @@ map.on("load", () => {
         : null;
     const boundariesLabel = datasetEntry ? datasetEntry.boundaries : eraKey;
     const imdLabel = datasetEntry ? datasetEntry.imd : (imdYear ?? "Unknown");
+    const localAuthorityLine =
+      nation === "northern_ireland"
+        ? "<div><strong>Local Government District:</strong> Not currently mapped in this layer</div>"
+        : `
+          <div><strong>Local Authority Name:</strong> ${localAuthorityName || "Unknown"}</div>
+          <div><strong>Local Authority Code:</strong> ${localAuthorityCode || "Unknown"}</div>
+          <div><strong>Local Authority Year:</strong> ${localAuthorityYear || "Unknown"}</div>
+        `;
 
     const content = `
       <div style="padding: 5px;">
@@ -299,6 +325,7 @@ map.on("load", () => {
         </strong>
         <div><strong>Name:</strong> ${areaName}</div>
         <div><strong>Code:</strong> ${areaCode}</div>
+        ${localAuthorityLine}
         <div><strong>Decile:</strong> ${decile === 0 ? "No Data" : decile}</div>
         <div style="margin-top: 5px; font-size: 0.8em; color: #666;">
           Boundaries: ${boundariesLabel} | Index: ${imdLabel}

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -36,6 +36,30 @@ if (!TILES_BASE_URL) {
   );
 }
 
+function getPropCaseInsensitive(props, candidateKeys) {
+  if (!props) return undefined;
+
+  for (const key of candidateKeys) {
+    if (props[key] !== undefined && props[key] !== null) {
+      return props[key];
+    }
+  }
+
+  const lowerMap = Object.create(null);
+  for (const key of Object.keys(props)) {
+    lowerMap[key.toLowerCase()] = props[key];
+  }
+
+  for (const key of candidateKeys) {
+    const value = lowerMap[key.toLowerCase()];
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
 let currentEra = "2021";
 
 function getViewName(era, zoom) {
@@ -199,17 +223,41 @@ map.on("load", () => {
 
     const feature = e.features[0];
     const props = feature.properties;
-    const decile = props.imd_decile;
+
+    const decile = getPropCaseInsensitive(props, ["imd_decile"]);
+    const nation = getPropCaseInsensitive(props, ["nation"]);
+    const areaName =
+      getPropCaseInsensitive(props, [
+        "area_name",
+        "areaname",
+        "name",
+        "lsoa_name",
+        "data_zone_name",
+        "soa_name",
+      ]) || "Unknown area";
+    const areaCode =
+      getPropCaseInsensitive(props, [
+        "code",
+        "lsoa_code",
+        "data_zone_code",
+        "soa_code",
+      ]) || "Unknown code";
+    const imdYear = getPropCaseInsensitive(props, ["imd_year", "year"]);
+
+    const areaLabel = nation
+      ? `${String(nation).replace(/_/g, " ").toUpperCase()} AREA`
+      : "AREA";
 
     const content = `
       <div style="padding: 5px;">
         <strong style="display: block; margin-bottom: 5px; border-bottom: 1px solid #ccc;">
-          ${props.nation.toUpperCase()} LSOA
+          ${areaLabel}
         </strong>
-        <div><strong>Code:</strong> ${props.code}</div>
+        <div><strong>Name:</strong> ${areaName}</div>
+        <div><strong>Code:</strong> ${areaCode}</div>
         <div><strong>Decile:</strong> ${decile === 0 ? "No Data" : decile}</div>
         <div style="margin-top: 5px; font-size: 0.8em; color: #666;">
-          Era: ${currentEra} | Data Year: ${props.imd_year}
+          Era: ${currentEra} | Data Year: ${imdYear ?? "Unknown"}
         </div>
       </div>
     `;

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -244,9 +244,16 @@ map.on("load", () => {
       ]) || "Unknown code";
     const imdYear = getPropCaseInsensitive(props, ["imd_year", "year"]);
 
+    const areaTypeLabel =
+      {
+        england: "LSOA",
+        wales: "LSOA",
+        scotland: "Data Zone",
+        northern_ireland: "SOA",
+      }[nation] || "Area";
     const areaLabel = nation
-      ? `${String(nation).replace(/_/g, " ").toUpperCase()} AREA`
-      : "AREA";
+      ? `${String(nation).replace(/_/g, " ").toUpperCase()} — ${areaTypeLabel}`
+      : "Area";
 
     const content = `
       <div style="padding: 5px;">
@@ -257,7 +264,7 @@ map.on("load", () => {
         <div><strong>Code:</strong> ${areaCode}</div>
         <div><strong>Decile:</strong> ${decile === 0 ? "No Data" : decile}</div>
         <div style="margin-top: 5px; font-size: 0.8em; color: #666;">
-          Era: ${currentEra} | Data Year: ${imdYear ?? "Unknown"}
+          Boundary Year: ${currentEra} | IMD Data Year: ${imdYear ?? "Unknown"}
         </div>
       </div>
     `;

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -60,7 +60,40 @@ function getPropCaseInsensitive(props, candidateKeys) {
   return undefined;
 }
 
+// Per-nation, per-era dataset facts
+// Scotland and NI are always on 2011-era boundaries regardless of era toggle.
+// Wales has no published 2025 WIMD, so this map uses 2019 WIMD on 2011 LSOAs.
+// (2021 Welsh boundaries may exist but are not used in the current UK-wide dataset.)
+// The era toggle therefore only affects England.
+// For the All UK view we always use uk_master_2011_* so all 4 nations appear.
+const DATASET_INFO = {
+  england: {
+    2021: { imd: "2025 IMD", boundaries: "2021 LSOAs" },
+    2011: { imd: "2019 IMD", boundaries: "2011 LSOAs" },
+  },
+  wales: {
+    2011: {
+      imd: "2019 WIMD",
+      boundaries: "2011 LSOAs",
+      note: "No 2025 WIMD published",
+    },
+  },
+  scotland: {
+    2011: { imd: "2020 SIMD", boundaries: "2011 DataZones" },
+  },
+  northern_ireland: {
+    2011: { imd: "2017 NIMDM", boundaries: "2001 SOAs" },
+  },
+};
+
 let currentEra = "2021";
+let currentNation = "all";
+
+// Returns the tile era to actually request for the given nation selection.
+// Only England solo respects the era toggle; everything else uses 2011.
+function effectiveEra(nation) {
+  return nation === "england" ? currentEra : "2011";
+}
 
 function getViewName(era, zoom) {
   const zoomSuffix = zoom <= 4 ? "z0_4" : zoom <= 7 ? "z5_7" : "z8_10";
@@ -151,7 +184,7 @@ function getColorExpression() {
 }
 
 function updateMapSource() {
-  const newLayer = getViewName(currentEra, map.getZoom());
+  const newLayer = getViewName(effectiveEra(currentNation), map.getZoom());
   const newTiles = [`${TILES_BASE_URL}/${newLayer}/{z}/{x}/{y}.pbf`];
 
   const currentFilter = map.getFilter("deprivation-layer");
@@ -190,7 +223,7 @@ function updateMapSource() {
 }
 
 map.on("load", () => {
-  const initialLayer = getViewName(currentEra, map.getZoom());
+  const initialLayer = getViewName(effectiveEra(currentNation), map.getZoom());
 
   map.addSource("deprivation-source", {
     type: "vector",
@@ -244,16 +277,20 @@ map.on("load", () => {
       ]) || "Unknown code";
     const imdYear = getPropCaseInsensitive(props, ["imd_year", "year"]);
 
-    const areaTypeLabel =
-      {
-        england: "LSOA",
-        wales: "LSOA",
-        scotland: "Data Zone",
-        northern_ireland: "SOA",
-      }[nation] || "Area";
     const areaLabel = nation
-      ? `${String(nation).replace(/_/g, " ").toUpperCase()} — ${areaTypeLabel}`
+      ? `${String(nation).replace(/_/g, " ").toUpperCase()}`
       : "Area";
+
+    // Look up the canonical boundary and IMD descriptions from DATASET_INFO
+    // so the tooltip always reflects the actual dataset for each nation,
+    // not just the raw era key (which would show "2011" for NI instead of "2001 SOAs").
+    const eraKey = effectiveEra(nation);
+    const datasetEntry =
+      nation && DATASET_INFO[nation] && DATASET_INFO[nation][eraKey]
+        ? DATASET_INFO[nation][eraKey]
+        : null;
+    const boundariesLabel = datasetEntry ? datasetEntry.boundaries : eraKey;
+    const imdLabel = datasetEntry ? datasetEntry.imd : (imdYear ?? "Unknown");
 
     const content = `
       <div style="padding: 5px;">
@@ -264,7 +301,7 @@ map.on("load", () => {
         <div><strong>Code:</strong> ${areaCode}</div>
         <div><strong>Decile:</strong> ${decile === 0 ? "No Data" : decile}</div>
         <div style="margin-top: 5px; font-size: 0.8em; color: #666;">
-          Boundary Year: ${currentEra} | IMD Data Year: ${imdYear ?? "Unknown"}
+          Boundaries: ${boundariesLabel} | Index: ${imdLabel}
         </div>
       </div>
     `;
@@ -278,20 +315,64 @@ map.on("load", () => {
   });
 });
 
+function updateDatasetInfo(selectedNation, era) {
+  const infoEl = document.getElementById("dataset-info");
+  const noteEl = document.getElementById("era-note");
+  const eraGroup = document.getElementById("era-toggle-group");
+  const eraSelect = document.getElementById("era-toggle");
+
+  const LABELS = {
+    england: "England",
+    wales: "Wales",
+    scotland: "Scotland",
+    northern_ireland: "N. Ireland",
+  };
+
+  // Era toggle is only meaningful when England is the sole selected nation.
+  const eraActive = selectedNation === "england";
+  eraGroup.style.opacity = eraActive ? "1" : "0.45";
+  eraSelect.disabled = !eraActive;
+  noteEl.textContent = eraActive
+    ? ""
+    : selectedNation === "all"
+      ? "All UK always shows latest data per country"
+      : "Era selector applies to England only";
+
+  const nations =
+    selectedNation === "all"
+      ? ["england", "wales", "scotland", "northern_ireland"]
+      : [selectedNation];
+
+  const lines = nations.map((n) => {
+    // England uses chosen era; all others are fixed on 2011.
+    const eraKey = n === "england" ? era : "2011";
+    const d = DATASET_INFO[n][eraKey];
+    const noteStr = d.note
+      ? ` <span style="color:#9a6700;font-style:italic;">(${d.note})</span>`
+      : "";
+    return `<div><strong>${LABELS[n]}:</strong> ${d.imd} &middot; ${d.boundaries}${noteStr}</div>`;
+  });
+
+  infoEl.innerHTML = lines.join("");
+}
+
 document.getElementById("era-toggle").addEventListener("change", (e) => {
   currentEra = e.target.value;
   updateMapSource();
+  updateDatasetInfo(currentNation, currentEra);
 });
 
 document.getElementById("nation-filter").addEventListener("change", (e) => {
-  const selectedNation = e.target.value;
+  currentNation = e.target.value;
+  const selectedNation = currentNation;
   map.setFilter(
     "deprivation-layer",
     selectedNation === "all" ? null : ["==", ["get", "nation"], selectedNation],
   );
-
-  // Update legend
+  // Changing nation may change the effective era (England→2021, others→2011)
+  updateMapSource();
   updateLegend(selectedNation);
+  updateDatasetInfo(selectedNation, currentEra);
 });
 
 function updateLegend(nation) {
@@ -353,5 +434,6 @@ function updateLegend(nation) {
   document.querySelector(".legend-title").textContent = title;
 }
 
-// Initialize legend
+// Initialize legend and dataset info panel
 updateLegend("all");
+updateDatasetInfo("all", currentEra);

--- a/tests/test_uk_master_local_authority_fields.py
+++ b/tests/test_uk_master_local_authority_fields.py
@@ -1,0 +1,84 @@
+import pytest
+from django.db import connection
+
+
+@pytest.mark.django_db
+def test_uk_master_tables_expose_local_authority_fields():
+    """UK master tile tables should expose LA metadata columns for tooltips."""
+    expected_columns = {"la_code", "la_name", "la_year"}
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT table_name, column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name IN ('uk_master_2011_z8_10', 'uk_master_2021_z8_10')
+              AND column_name IN ('la_code', 'la_name', 'la_year')
+            ORDER BY table_name, column_name
+            """
+        )
+        rows = cursor.fetchall()
+
+    found = {
+        "uk_master_2011_z8_10": set(),
+        "uk_master_2021_z8_10": set(),
+    }
+    for table_name, column_name in rows:
+        found[table_name].add(column_name)
+
+    assert found["uk_master_2011_z8_10"] == expected_columns
+    assert found["uk_master_2021_z8_10"] == expected_columns
+
+
+@pytest.mark.django_db
+def test_uk_master_2011_local_authority_population_by_nation():
+    """
+    LA metadata should be populated for England/Wales/Scotland and null for NI.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT nation,
+                   COUNT(*) AS total_rows,
+                   COUNT(*) FILTER (WHERE la_code IS NULL) AS null_la_code,
+                   COUNT(*) FILTER (WHERE la_name IS NULL) AS null_la_name,
+                   COUNT(*) FILTER (WHERE la_year IS NULL) AS null_la_year
+            FROM public.uk_master_2011_z8_10
+            GROUP BY nation
+            ORDER BY nation
+            """
+        )
+        rows = cursor.fetchall()
+
+    by_nation = {
+        nation: {
+            "total_rows": total_rows,
+            "null_la_code": null_la_code,
+            "null_la_name": null_la_name,
+            "null_la_year": null_la_year,
+        }
+        for nation, total_rows, null_la_code, null_la_name, null_la_year in rows
+    }
+
+    for nation in ["england", "wales", "scotland"]:
+        assert nation in by_nation, f"Missing nation in tile table: {nation}"
+        assert by_nation[nation]["total_rows"] > 0
+        assert by_nation[nation]["null_la_code"] == 0
+        assert by_nation[nation]["null_la_name"] == 0
+        assert by_nation[nation]["null_la_year"] == 0
+
+    assert "northern_ireland" in by_nation
+    assert by_nation["northern_ireland"]["total_rows"] > 0
+    assert (
+        by_nation["northern_ireland"]["null_la_code"]
+        == by_nation["northern_ireland"]["total_rows"]
+    )
+    assert (
+        by_nation["northern_ireland"]["null_la_name"]
+        == by_nation["northern_ireland"]["total_rows"]
+    )
+    assert (
+        by_nation["northern_ireland"]["null_la_year"]
+        == by_nation["northern_ireland"]["total_rows"]
+    )

--- a/tests/test_uk_master_local_authority_fields.py
+++ b/tests/test_uk_master_local_authority_fields.py
@@ -1,33 +1,29 @@
 import pytest
 from django.db import connection
 
-
-def _uk_master_tables_exist():
-    """Return True if the uk_master materialized tile tables have been created."""
-    with connection.cursor() as cursor:
-        cursor.execute(
-            """
-            SELECT COUNT(*) FROM information_schema.tables
-            WHERE table_schema = 'public'
-              AND table_name = 'uk_master_2011_z8_10'
-            """
-        )
-        return cursor.fetchone()[0] == 1
+_SKIP_REASON = "uk_master tile tables not present — run 'seed --mode process_geometries' first"
 
 
-requires_tile_tables = pytest.mark.skipif(
-    not _uk_master_tables_exist(),
-    reason="uk_master tile tables not present — run 'seed --mode process_geometries' first",
-)
+def _skip_if_no_tile_tables(cursor):
+    """Call pytest.skip() inside a test if the uk_master tables haven't been built."""
+    cursor.execute(
+        """
+        SELECT COUNT(*) FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'uk_master_2011_z8_10'
+        """
+    )
+    if cursor.fetchone()[0] == 0:
+        pytest.skip(_SKIP_REASON)
 
 
-@requires_tile_tables
 @pytest.mark.django_db
 def test_uk_master_tables_expose_local_authority_fields():
     """UK master tile tables should expose LA metadata columns for tooltips."""
     expected_columns = {"la_code", "la_name", "la_year"}
 
     with connection.cursor() as cursor:
+        _skip_if_no_tile_tables(cursor)
         cursor.execute(
             """
             SELECT table_name, column_name
@@ -51,13 +47,13 @@ def test_uk_master_tables_expose_local_authority_fields():
     assert found["uk_master_2021_z8_10"] == expected_columns
 
 
-@requires_tile_tables
 @pytest.mark.django_db
 def test_uk_master_2011_local_authority_population_by_nation():
     """
     LA metadata should be populated for England/Wales/Scotland and null for NI.
     """
     with connection.cursor() as cursor:
+        _skip_if_no_tile_tables(cursor)
         cursor.execute(
             """
             SELECT nation,

--- a/tests/test_uk_master_local_authority_fields.py
+++ b/tests/test_uk_master_local_authority_fields.py
@@ -1,7 +1,9 @@
 import pytest
 from django.db import connection
 
-_SKIP_REASON = "uk_master tile tables not present — run 'seed --mode process_geometries' first"
+_SKIP_REASON = (
+    "uk_master tile tables not present — run 'seed --mode process_geometries' first"
+)
 
 
 def _skip_if_no_tile_tables(cursor):

--- a/tests/test_uk_master_local_authority_fields.py
+++ b/tests/test_uk_master_local_authority_fields.py
@@ -2,6 +2,26 @@ import pytest
 from django.db import connection
 
 
+def _uk_master_tables_exist():
+    """Return True if the uk_master materialized tile tables have been created."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT COUNT(*) FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_name = 'uk_master_2011_z8_10'
+            """
+        )
+        return cursor.fetchone()[0] == 1
+
+
+requires_tile_tables = pytest.mark.skipif(
+    not _uk_master_tables_exist(),
+    reason="uk_master tile tables not present — run 'seed --mode process_geometries' first",
+)
+
+
+@requires_tile_tables
 @pytest.mark.django_db
 def test_uk_master_tables_expose_local_authority_fields():
     """UK master tile tables should expose LA metadata columns for tooltips."""
@@ -31,6 +51,7 @@ def test_uk_master_tables_expose_local_authority_fields():
     assert found["uk_master_2021_z8_10"] == expected_columns
 
 
+@requires_tile_tables
 @pytest.mark.django_db
 def test_uk_master_2011_local_authority_population_by_nation():
     """


### PR DESCRIPTION
## Summary

This PR improves map clarity and metadata exposure across UK deprivation layers, adds an optional Local Authority boundary overlay, and strengthens operator/developer workflow docs and tests.

## What changed

### 1) Expose human-readable area names in tiles
- Added `area_name` to tile materialization SQL for:
  - `public.uk_master_*`
  - `public.lsoa_tiles_*`
- Populated per nation using source names:
  - England/Wales: `lsoa_name`
  - Scotland: `data_zone_name`
  - Northern Ireland: `soa_name`

### 2) Expose Local Authority metadata in UK tiles
- Added to `public.uk_master_*`:
  - `la_code`
  - `la_name`
  - `la_year`
- England/Wales/Scotland are populated via seeded lookup relationships.
- Northern Ireland is explicitly set to `NULL` for `la_*` fields in current layer.

### 3) Frontend tooltip hardening and data signposting
- Added robust case-insensitive property lookup strategy.
- Tooltip now reliably shows:
  - Name/code
  - Boundaries + index context
  - Local Authority name/code/year (or NI-specific LGD message)
- Corrected labeling text for Wales dataset caveat (missing 2025 WIMD publication).
- Ensured boundary/index labels reflect actual rendered dataset logic by nation.

### 4) Era/nation behavior cleanup
- Era toggle applies meaningfully to England-only view.
- UK-wide and non-England views use effective fixed datasets where appropriate.
- Dataset information panel updated to clearly signpost what users are seeing.

### 5) Optional Local Authority boundary overlay (frontend)
- Added map control toggle: “Show Local Authority boundaries”.
- Added LA line overlay layer from `public.la_tiles`.
- Conditional rendering/filtering:
  - England: LAD 2019 (era 2011) or LAD 2024 (era 2021)
  - Wales: LAD 2019
  - Scotland: LA 2011
  - Northern Ireland: disabled/not rendered in this layer
- Kept overlay visible across zoom/source swaps and adjusted visual styling:
  - Softer color and thinner line ramp for better hierarchy.

### 6) Documentation updates
- Expanded boundary documentation to include:
  - explicit mapping table of boundary year vs IMD year vs LA year by nation/view
  - NI caveat for `la_*` applicability
  - updated exposed tile keys
- Updated AGENTS operational guidance to:
  - reference `site/docs` as source of truth
  - signpost publishing/deployment docs
  - document high-level data release/deploy workflow:
    1. seed/build dump locally
    2. publish to GitHub Releases (chunked when large)
    3. restore in Azure managed PostgreSQL
    4. deploy app containers separately

### 7) New test tooling + tests
- Added `s/test` convenience script to run pytest from host with pass-through flags (using running web container or one-off container as needed).
- Added targeted tests for LA fields in UK master tiles:
  - column presence (`la_code`, `la_name`, `la_year`)
  - expected population by nation (E/W/S populated, NI null)
- Tests run via:
  - `./s/test -q tests/test_uk_master_local_authority_fields.py`

## Files changed (high level)

- `deprivation_scores/management/commands/seed.py`
- `site/map-logic.js`
- `site/index.html`
- `site/docs/boundaries.md`
- `AGENTS.md`
- `s/test` (new)
- `tests/test_uk_master_local_authority_fields.py` (new)

## Validation performed

- pg_tileserv metadata confirms new UK tile properties including `area_name` and `la_*`.
- DB checks confirm:
  - 100% join coverage for LSOA/DataZone -> Local Authority where expected
  - expected LA year linkage:
    - LSOA 2011 -> LA 2019
    - LSOA 2021 -> LA 2024
    - DataZone 2011 -> LA 2011
  - NI rows have `la_* = NULL` in UK master tiles (by design)
- New LA tests pass via `s/test`.

## Notes

- Tile schema changes require `python manage.py seed --mode process_geometries` to rebuild materialized tile tables.
- NI Local Government District support is explicitly out-of-scope in this PR; UI messaging reflects that.

close #46