### PR TITLE
Bump tileserver allocation

### DIFF
--- a/infra/azure/containerapp.template.yml
+++ b/infra/azure/containerapp.template.yml
@@ -82,6 +82,7 @@ properties:
           - name: TILES_BASE_URL
             secretRef: tiles-base-url
         resources:
-          cpu: 0.5
-          memory: 1.0Gi
+          # 23/04/26 - increased to see if it improves initial rendering performance of each tile
+          cpu: 2.5
+          memory: 5.0Gi
   


### PR DESCRIPTION
When we first added the new maps to E12 (https://github.com/rcpch/rcpch-audit-engine/pull/1367) the loading performance is slow.

Whilst we've switched the maps to a new client (https://github.com/rcpch/rcpch-audit-engine/pull/1377) this will not necessarily improve performance on it's own.

So bump up the resoures for the tile server to the maximum available on the Azure Container Apps on demand plan to see if it helps!