### PR TITLE
Clarify database timeout

### DIFF
--- a/infra/azure/containerapp.template.yml
+++ b/infra/azure/containerapp.template.yml
@@ -70,7 +70,7 @@ properties:
             [server]
             HttpHost = "0.0.0.0"
             HttpPort = 7800
-            DbTimeout = 30000
+            DbTimeout = "30s"
             
             [database]
             EOF


### PR DESCRIPTION
We're seeing a lot of `Timeout: deadline exceeded on public.uk_master_2011_z5_7/6/32/20.pbf\ntimeout: context deadline exceeded` errors

We're not 100% sure why this happens in Azure. But Claude did suggest that we clarify the database timeout as it thought some places might not consistently parse it as 30 seconds as intended.

Let's send this out and see if it makes a difference!