### PR TITLE
map-component-optimised

### DIFF
--- a/deprivation_scores/management/commands/seed.py
+++ b/deprivation_scores/management/commands/seed.py
@@ -401,14 +401,82 @@ class Command(BaseCommand):
             "DROP TABLE IF EXISTS public.lsoa_tiles_2011_z11_14 CASCADE;",
             "DROP TABLE IF EXISTS public.lsoa_tiles_2021_z11_14 CASCADE;",
             "DROP TABLE IF EXISTS public.lsoa_tiles_2021_z0_4 CASCADE;",
-            "DROP VIEW IF EXISTS public.la_tiles CASCADE;",
-            "DROP VIEW IF EXISTS public.nhser_tiles_2021 CASCADE;",
-            "DROP VIEW IF EXISTS public.icb_tiles_2023 CASCADE;",
-            "DROP VIEW IF EXISTS public.lhb_tiles_2022 CASCADE;",
-            "DROP TABLE IF EXISTS public.la_tiles CASCADE;",
-            "DROP TABLE IF EXISTS public.nhser_tiles_2021 CASCADE;",
-            "DROP TABLE IF EXISTS public.icb_tiles_2023 CASCADE;",
-            "DROP TABLE IF EXISTS public.lhb_tiles_2022 CASCADE;",
+            """
+            DO $$
+            DECLARE
+                relkind_char char;
+            BEGIN
+                SELECT c.relkind INTO relkind_char
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'public' AND c.relname = 'la_tiles';
+
+                IF relkind_char = 'r' THEN
+                    EXECUTE 'DROP TABLE public.la_tiles CASCADE';
+                ELSIF relkind_char = 'v' THEN
+                    EXECUTE 'DROP VIEW public.la_tiles CASCADE';
+                ELSIF relkind_char = 'm' THEN
+                    EXECUTE 'DROP MATERIALIZED VIEW public.la_tiles CASCADE';
+                END IF;
+            END $$;
+            """,
+            """
+            DO $$
+            DECLARE
+                relkind_char char;
+            BEGIN
+                SELECT c.relkind INTO relkind_char
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'public' AND c.relname = 'nhser_tiles_2021';
+
+                IF relkind_char = 'r' THEN
+                    EXECUTE 'DROP TABLE public.nhser_tiles_2021 CASCADE';
+                ELSIF relkind_char = 'v' THEN
+                    EXECUTE 'DROP VIEW public.nhser_tiles_2021 CASCADE';
+                ELSIF relkind_char = 'm' THEN
+                    EXECUTE 'DROP MATERIALIZED VIEW public.nhser_tiles_2021 CASCADE';
+                END IF;
+            END $$;
+            """,
+            """
+            DO $$
+            DECLARE
+                relkind_char char;
+            BEGIN
+                SELECT c.relkind INTO relkind_char
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'public' AND c.relname = 'icb_tiles_2023';
+
+                IF relkind_char = 'r' THEN
+                    EXECUTE 'DROP TABLE public.icb_tiles_2023 CASCADE';
+                ELSIF relkind_char = 'v' THEN
+                    EXECUTE 'DROP VIEW public.icb_tiles_2023 CASCADE';
+                ELSIF relkind_char = 'm' THEN
+                    EXECUTE 'DROP MATERIALIZED VIEW public.icb_tiles_2023 CASCADE';
+                END IF;
+            END $$;
+            """,
+            """
+            DO $$
+            DECLARE
+                relkind_char char;
+            BEGIN
+                SELECT c.relkind INTO relkind_char
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'public' AND c.relname = 'lhb_tiles_2022';
+
+                IF relkind_char = 'r' THEN
+                    EXECUTE 'DROP TABLE public.lhb_tiles_2022 CASCADE';
+                ELSIF relkind_char = 'v' THEN
+                    EXECUTE 'DROP VIEW public.lhb_tiles_2022 CASCADE';
+                ELSIF relkind_char = 'm' THEN
+                    EXECUTE 'DROP MATERIALIZED VIEW public.lhb_tiles_2022 CASCADE';
+                END IF;
+            END $$;
+            """,
             "DROP TABLE IF EXISTS public.nhser_tiles_2021_z0_4 CASCADE;",
             "DROP TABLE IF EXISTS public.nhser_tiles_2021_z5_7 CASCADE;",
             "DROP TABLE IF EXISTS public.nhser_tiles_2021_z8_10 CASCADE;",

--- a/deprivation_scores/management/commands/seed.py
+++ b/deprivation_scores/management/commands/seed.py
@@ -337,6 +337,28 @@ class Command(BaseCommand):
             ANALYZE public.{view_name};
             """
 
+        def get_health_boundary_view_sql(
+            view_name, source_table, code_column, name_column, year, nation, geom_column
+        ):
+            """Create a zoom-banded health boundary tile table."""
+            return f"""
+            DROP TABLE IF EXISTS public.{view_name} CASCADE;
+
+            CREATE TABLE public.{view_name} AS
+            SELECT
+                year::int AS year,
+                {code_column}::text AS code,
+                {name_column}::text AS area_name,
+                ST_MakeValid(ST_Multi({geom_column}))::geometry(MultiPolygon, 3857) AS geom,
+                '{nation}'::text AS nation
+            FROM {source_table}
+            WHERE year = {year}
+              AND {geom_column} IS NOT NULL;
+
+            CREATE INDEX idx_{view_name}_geom ON public.{view_name} USING GIST (geom);
+            ANALYZE public.{view_name};
+            """
+
         # --- SQL Statement List ---
 
         sql_statements = [
@@ -387,6 +409,18 @@ class Command(BaseCommand):
             "DROP TABLE IF EXISTS public.nhser_tiles_2021 CASCADE;",
             "DROP TABLE IF EXISTS public.icb_tiles_2023 CASCADE;",
             "DROP TABLE IF EXISTS public.lhb_tiles_2022 CASCADE;",
+            "DROP TABLE IF EXISTS public.nhser_tiles_2021_z0_4 CASCADE;",
+            "DROP TABLE IF EXISTS public.nhser_tiles_2021_z5_7 CASCADE;",
+            "DROP TABLE IF EXISTS public.nhser_tiles_2021_z8_10 CASCADE;",
+            "DROP TABLE IF EXISTS public.nhser_tiles_2021_z11_14 CASCADE;",
+            "DROP TABLE IF EXISTS public.icb_tiles_2023_z0_4 CASCADE;",
+            "DROP TABLE IF EXISTS public.icb_tiles_2023_z5_7 CASCADE;",
+            "DROP TABLE IF EXISTS public.icb_tiles_2023_z8_10 CASCADE;",
+            "DROP TABLE IF EXISTS public.icb_tiles_2023_z11_14 CASCADE;",
+            "DROP TABLE IF EXISTS public.lhb_tiles_2022_z0_4 CASCADE;",
+            "DROP TABLE IF EXISTS public.lhb_tiles_2022_z5_7 CASCADE;",
+            "DROP TABLE IF EXISTS public.lhb_tiles_2022_z8_10 CASCADE;",
+            "DROP TABLE IF EXISTS public.lhb_tiles_2022_z11_14 CASCADE;",
             # Section 3: Geoprocessing (WGS84 -> Web Mercator 3857)
             "UPDATE deprivation_scores_lsoa SET geom_3857 = ST_MakeValid(geom_3857) WHERE NOT ST_IsValid(geom_3857);",
             "UPDATE deprivation_scores_lsoa SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
@@ -398,13 +432,13 @@ class Command(BaseCommand):
             "UPDATE deprivation_scores_localhealthboard SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
             # Section 4: Simplification
             # Compute all simplification tiers in a single pass per table to reduce write overhead.
-            # z0-4: 1,500 m, z5-7: 200 m, z8-10: 30 m (all in EPSG:3857 metres).
-            "UPDATE deprivation_scores_lsoa SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 30)), 3)) WHERE geom_3857 IS NOT NULL;",
-            "UPDATE deprivation_scores_datazone SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 30)), 3)) WHERE geom_3857 IS NOT NULL;",
-            "UPDATE deprivation_scores_soa SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 30)), 3)) WHERE geom_3857 IS NOT NULL;",
-            "UPDATE deprivation_scores_nhsenglishregion SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 30)), 3)) WHERE geom_3857 IS NOT NULL;",
-            "UPDATE deprivation_scores_integratedcareboard SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 30)), 3)) WHERE geom_3857 IS NOT NULL;",
-            "UPDATE deprivation_scores_localhealthboard SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 30)), 3)) WHERE geom_3857 IS NOT NULL;",
+            # z0-4: 1,500 m, z5-7: 200 m, z8-10: 60 m (all in EPSG:3857 metres).
+            "UPDATE deprivation_scores_lsoa SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+            "UPDATE deprivation_scores_datazone SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+            "UPDATE deprivation_scores_soa SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+            "UPDATE deprivation_scores_nhsenglishregion SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+            "UPDATE deprivation_scores_integratedcareboard SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+            "UPDATE deprivation_scores_localhealthboard SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
             # Section 5: Spatial indexing & clustering
             # Raw geometry indexes (for z11+ and raw queries)
             "CREATE INDEX IF NOT EXISTS idx_lsoa_3857 ON deprivation_scores_lsoa USING GIST (geom_3857);",
@@ -466,15 +500,117 @@ class Command(BaseCommand):
             "CREATE TABLE public.la_tiles AS SELECT year::int AS year, local_authority_district_code::text AS lad_code, ST_MakeValid(ST_Multi(geom_3857))::geometry(MultiPolygon, 3857) AS geom FROM deprivation_scores_localauthority WHERE geom_3857 IS NOT NULL;",
             "CREATE INDEX idx_la_tiles_geom ON public.la_tiles USING GIST (geom);",
             "ANALYZE public.la_tiles;",
-            "CREATE TABLE public.nhser_tiles_2021 AS SELECT year::int AS year, nhser_code::text AS code, nhser_name::text AS area_name, ST_MakeValid(ST_Multi(geom_3857))::geometry(MultiPolygon, 3857) AS geom, 'england'::text AS nation FROM deprivation_scores_nhsenglishregion WHERE year = 2021 AND geom_3857 IS NOT NULL;",
-            "CREATE INDEX idx_nhser_tiles_2021_geom ON public.nhser_tiles_2021 USING GIST (geom);",
-            "ANALYZE public.nhser_tiles_2021;",
-            "CREATE TABLE public.icb_tiles_2023 AS SELECT year::int AS year, icb_code::text AS code, icb_name::text AS area_name, ST_MakeValid(ST_Multi(geom_3857))::geometry(MultiPolygon, 3857) AS geom, 'england'::text AS nation FROM deprivation_scores_integratedcareboard WHERE year = 2023 AND geom_3857 IS NOT NULL;",
-            "CREATE INDEX idx_icb_tiles_2023_geom ON public.icb_tiles_2023 USING GIST (geom);",
-            "ANALYZE public.icb_tiles_2023;",
-            "CREATE TABLE public.lhb_tiles_2022 AS SELECT year::int AS year, lhb_code::text AS code, lhb_name::text AS area_name, ST_MakeValid(ST_Multi(geom_3857))::geometry(MultiPolygon, 3857) AS geom, 'wales'::text AS nation FROM deprivation_scores_localhealthboard WHERE year = 2022 AND geom_3857 IS NOT NULL;",
-            "CREATE INDEX idx_lhb_tiles_2022_geom ON public.lhb_tiles_2022 USING GIST (geom);",
-            "ANALYZE public.lhb_tiles_2022;",
+            get_health_boundary_view_sql(
+                "nhser_tiles_2021_z0_4",
+                "deprivation_scores_nhsenglishregion",
+                "nhser_code",
+                "nhser_name",
+                2021,
+                "england",
+                "geom_3857_simp_z0_4",
+            ),
+            get_health_boundary_view_sql(
+                "nhser_tiles_2021_z5_7",
+                "deprivation_scores_nhsenglishregion",
+                "nhser_code",
+                "nhser_name",
+                2021,
+                "england",
+                "geom_3857_simp_z5_7",
+            ),
+            get_health_boundary_view_sql(
+                "nhser_tiles_2021_z8_10",
+                "deprivation_scores_nhsenglishregion",
+                "nhser_code",
+                "nhser_name",
+                2021,
+                "england",
+                "geom_3857",
+            ),
+            get_health_boundary_view_sql(
+                "nhser_tiles_2021_z11_14",
+                "deprivation_scores_nhsenglishregion",
+                "nhser_code",
+                "nhser_name",
+                2021,
+                "england",
+                "geom_3857",
+            ),
+            get_health_boundary_view_sql(
+                "icb_tiles_2023_z0_4",
+                "deprivation_scores_integratedcareboard",
+                "icb_code",
+                "icb_name",
+                2023,
+                "england",
+                "geom_3857_simp_z0_4",
+            ),
+            get_health_boundary_view_sql(
+                "icb_tiles_2023_z5_7",
+                "deprivation_scores_integratedcareboard",
+                "icb_code",
+                "icb_name",
+                2023,
+                "england",
+                "geom_3857_simp_z5_7",
+            ),
+            get_health_boundary_view_sql(
+                "icb_tiles_2023_z8_10",
+                "deprivation_scores_integratedcareboard",
+                "icb_code",
+                "icb_name",
+                2023,
+                "england",
+                "geom_3857",
+            ),
+            get_health_boundary_view_sql(
+                "icb_tiles_2023_z11_14",
+                "deprivation_scores_integratedcareboard",
+                "icb_code",
+                "icb_name",
+                2023,
+                "england",
+                "geom_3857",
+            ),
+            get_health_boundary_view_sql(
+                "lhb_tiles_2022_z0_4",
+                "deprivation_scores_localhealthboard",
+                "lhb_code",
+                "lhb_name",
+                2022,
+                "wales",
+                "geom_3857_simp_z0_4",
+            ),
+            get_health_boundary_view_sql(
+                "lhb_tiles_2022_z5_7",
+                "deprivation_scores_localhealthboard",
+                "lhb_code",
+                "lhb_name",
+                2022,
+                "wales",
+                "geom_3857_simp_z5_7",
+            ),
+            get_health_boundary_view_sql(
+                "lhb_tiles_2022_z8_10",
+                "deprivation_scores_localhealthboard",
+                "lhb_code",
+                "lhb_name",
+                2022,
+                "wales",
+                "geom_3857",
+            ),
+            get_health_boundary_view_sql(
+                "lhb_tiles_2022_z11_14",
+                "deprivation_scores_localhealthboard",
+                "lhb_code",
+                "lhb_name",
+                2022,
+                "wales",
+                "geom_3857",
+            ),
+            "CREATE VIEW public.nhser_tiles_2021 AS SELECT * FROM public.nhser_tiles_2021_z11_14;",
+            "CREATE VIEW public.icb_tiles_2023 AS SELECT * FROM public.icb_tiles_2023_z11_14;",
+            "CREATE VIEW public.lhb_tiles_2022 AS SELECT * FROM public.lhb_tiles_2022_z11_14;",
             # Section 8: Final housekeeping
             "GRANT SELECT ON ALL TABLES IN SCHEMA public TO PUBLIC;",
             "ANALYZE deprivation_scores_lsoa;",
@@ -491,9 +627,18 @@ class Command(BaseCommand):
             "VACUUM ANALYZE public.lsoa_tiles_2011_z11_14;",
             "VACUUM ANALYZE public.lsoa_tiles_2021_z11_14;",
             "VACUUM ANALYZE public.la_tiles;",
-            "VACUUM ANALYZE public.nhser_tiles_2021;",
-            "VACUUM ANALYZE public.icb_tiles_2023;",
-            "VACUUM ANALYZE public.lhb_tiles_2022;",
+            "VACUUM ANALYZE public.nhser_tiles_2021_z0_4;",
+            "VACUUM ANALYZE public.nhser_tiles_2021_z5_7;",
+            "VACUUM ANALYZE public.nhser_tiles_2021_z8_10;",
+            "VACUUM ANALYZE public.nhser_tiles_2021_z11_14;",
+            "VACUUM ANALYZE public.icb_tiles_2023_z0_4;",
+            "VACUUM ANALYZE public.icb_tiles_2023_z5_7;",
+            "VACUUM ANALYZE public.icb_tiles_2023_z8_10;",
+            "VACUUM ANALYZE public.icb_tiles_2023_z11_14;",
+            "VACUUM ANALYZE public.lhb_tiles_2022_z0_4;",
+            "VACUUM ANALYZE public.lhb_tiles_2022_z5_7;",
+            "VACUUM ANALYZE public.lhb_tiles_2022_z8_10;",
+            "VACUUM ANALYZE public.lhb_tiles_2022_z11_14;",
         ]
 
         print("[POSTPROCESS] Starting SQL post-processing...")

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>UK Deprivation Map | Era Comparison</title>
     <link rel="icon" type="image/png" href="rcpch_logo.png">
-    <script src="https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.js"></script>
     <link href="https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.css" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.14/dist/full.min.css" rel="stylesheet" type="text/css" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -67,48 +66,6 @@
             margin-bottom: 8px; 
             font-size: 0.875rem; 
             color: #0d0d58; 
-        }
-
-        /* The Legend Styling */
-        .legend {
-            position: absolute; 
-            bottom: 30px; 
-            right: 20px; 
-            z-index: 10;
-            background: white; 
-            padding: 15px; 
-            border-radius: 8px;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1); 
-            font-size: 0.8rem;
-            max-width: 250px;
-        }
-        
-        .legend-title { 
-            font-weight: bold; 
-            margin-bottom: 8px; 
-            text-align: center;
-            color: #0d0d58;
-        }
-        
-        .legend-scale { 
-            display: flex; 
-            flex-direction: column; 
-            gap: 4px; 
-        }
-        
-        .legend-item { 
-            display: flex; 
-            align-items: center; 
-            gap: 10px; 
-            font-size: 0.75rem;
-        }
-        
-        .color-box { 
-            width: 20px; 
-            height: 12px; 
-            border: 1px solid #ddd; 
-            border-radius: 2px; 
-            flex-shrink: 0;
         }
 
         .maplibregl-popup {
@@ -221,21 +178,19 @@
     </div>
 </div>
 
-<!-- Legend (content will be populated dynamically) -->
-<div class="legend">
-    <div class="legend-title">Deprivation Decile (All Nations)</div>
-    <div class="legend-scale">
-        <div class="legend-item"><div class="color-box" style="background: #67000d;"></div> England - Most Deprived</div>
-        <div class="legend-item"><div class="color-box" style="background: #08306b;"></div> Scotland - Most Deprived</div>
-        <div class="legend-item"><div class="color-box" style="background: #00441b;"></div> Wales - Most Deprived</div>
-        <div class="legend-item"><div class="color-box" style="background: #7f2704;"></div> N. Ireland - Most Deprived</div>
-        <div class="legend-item"><div class="color-box" style="background: #cccccc;"></div> No Data</div>
-    </div>
-</div>
-
 <div id="map"></div>
 
 <script src="config.js"></script>
+<!--
+Update process for @rcpch/imd-map CDN pin:
+1) npm view @rcpch/imd-map version
+2) curl -s https://cdn.jsdelivr.net/npm/@rcpch/imd-map@<version>/dist/umd/rcpch-imd-map.min.js | openssl dgst -sha384 -binary | openssl base64 -A | xargs -I {} echo "sha384-{}"
+Then update both the @<version> in src and the integrity value below.
+-->
+<script
+    src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.1.2/dist/umd/rcpch-imd-map.min.js"
+    integrity="sha384-SOHGpklzaQ2QQRsOvUcliOu8PNNPAqt5H7GMjmNAV0VTsuJQO1ploVvDZ8N/4AmC"
+    crossorigin="anonymous"></script>
 <script src="map-logic.js"></script>
 
 </body>

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -97,7 +97,7 @@ const HEALTH_BOUNDARIES = {
   nhser: {
     sourceId: "nhser-boundaries-source",
     layerId: "nhser-boundaries-layer",
-    sourceLayer: "public.nhser_tiles_2021",
+    sourceLayerBase: "public.nhser_tiles_2021",
     toggleId: "nhser-toggle",
     groupId: "nhser-toggle-group",
     noteId: "nhser-note",
@@ -109,7 +109,7 @@ const HEALTH_BOUNDARIES = {
   icb: {
     sourceId: "icb-boundaries-source",
     layerId: "icb-boundaries-layer",
-    sourceLayer: "public.icb_tiles_2023",
+    sourceLayerBase: "public.icb_tiles_2023",
     toggleId: "icb-toggle",
     groupId: "icb-toggle-group",
     noteId: "icb-note",
@@ -121,7 +121,7 @@ const HEALTH_BOUNDARIES = {
   lhb: {
     sourceId: "lhb-boundaries-source",
     layerId: "lhb-boundaries-layer",
-    sourceLayer: "public.lhb_tiles_2022",
+    sourceLayerBase: "public.lhb_tiles_2022",
     toggleId: "lhb-toggle",
     groupId: "lhb-toggle-group",
     noteId: "lhb-note",
@@ -142,6 +142,12 @@ function getViewName(era, zoom) {
   const zoomSuffix =
     zoom <= 4 ? "z0_4" : zoom <= 7 ? "z5_7" : zoom <= 10 ? "z8_10" : "z11_14";
   return `public.uk_master_${era}_${zoomSuffix}`;
+}
+
+function getHealthBoundaryViewName(sourceLayerBase, zoom) {
+  const zoomSuffix =
+    zoom <= 4 ? "z0_4" : zoom <= 7 ? "z5_7" : zoom <= 10 ? "z8_10" : "z11_14";
+  return `${sourceLayerBase}_${zoomSuffix}`;
 }
 
 function getLocalAuthorityYearForNation(nation) {
@@ -298,16 +304,27 @@ function isHealthBoundaryEnabledForCurrentNation(config) {
 }
 
 function ensureHealthBoundarySource(config) {
+  const sourceLayer = getHealthBoundaryViewName(
+    config.sourceLayerBase,
+    map.getZoom(),
+  );
+
+  if (map.getLayer(config.layerId)) {
+    map.removeLayer(config.layerId);
+  }
+
   if (map.getSource(config.sourceId)) {
-    return;
+    map.removeSource(config.sourceId);
   }
 
   map.addSource(config.sourceId, {
     type: "vector",
-    tiles: [`${TILES_BASE_URL}/${config.sourceLayer}/{z}/{x}/{y}.pbf`],
+    tiles: [`${TILES_BASE_URL}/${sourceLayer}/{z}/{x}/{y}.pbf`],
     minzoom: 0,
     maxzoom: 14,
   });
+
+  return sourceLayer;
 }
 
 function removeHealthBoundaryLayer(config) {
@@ -327,14 +344,14 @@ function updateHealthBoundaryLayer(boundaryKey) {
     return;
   }
 
-  ensureHealthBoundarySource(config);
+  const sourceLayer = ensureHealthBoundarySource(config);
 
   if (!map.getLayer(config.layerId)) {
     map.addLayer({
       id: config.layerId,
       type: "line",
       source: config.sourceId,
-      "source-layer": config.sourceLayer,
+      "source-layer": sourceLayer,
       paint: {
         "line-color": config.color,
         "line-width": [

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -1,11 +1,3 @@
-const map = new maplibregl.Map({
-  container: "map",
-  style: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
-  center: [-3.43, 55.37],
-  zoom: 5,
-  refreshExpired: true,
-});
-
 function getTilesBaseUrl() {
   const params = new URLSearchParams(window.location.search);
   const fromQuery = params.get("tilesBase");
@@ -36,36 +28,6 @@ if (!TILES_BASE_URL) {
   );
 }
 
-function getPropCaseInsensitive(props, candidateKeys) {
-  if (!props) return undefined;
-
-  for (const key of candidateKeys) {
-    if (props[key] !== undefined && props[key] !== null) {
-      return props[key];
-    }
-  }
-
-  const lowerMap = Object.create(null);
-  for (const key of Object.keys(props)) {
-    lowerMap[key.toLowerCase()] = props[key];
-  }
-
-  for (const key of candidateKeys) {
-    const value = lowerMap[key.toLowerCase()];
-    if (value !== undefined && value !== null) {
-      return value;
-    }
-  }
-
-  return undefined;
-}
-
-// Per-nation, per-era dataset facts
-// Scotland and NI are always on 2011-era boundaries regardless of era toggle.
-// Wales has no published 2025 WIMD, so this map uses 2019 WIMD on 2011 LSOAs.
-// (2021 Welsh boundaries may exist but are not used in the current UK-wide dataset.)
-// The era toggle therefore only affects England.
-// For the All UK view we always use uk_master_2011_* so all 4 nations appear.
 const DATASET_INFO = {
   england: {
     2021: { imd: "2025 IMD", boundaries: "2021 LSOAs" },
@@ -88,193 +50,74 @@ const DATASET_INFO = {
 
 let currentEra = "2021";
 let currentNation = "all";
-
-const LA_SOURCE_ID = "la-boundaries-source";
-const LA_LAYER_ID = "la-boundaries-layer";
-const LA_SOURCE_LAYER = "public.la_tiles";
+let mapInstance = null;
 
 const HEALTH_BOUNDARIES = {
   nhser: {
-    sourceId: "nhser-boundaries-source",
-    layerId: "nhser-boundaries-layer",
-    sourceLayerBase: "public.nhser_tiles_2021",
     toggleId: "nhser-toggle",
     groupId: "nhser-toggle-group",
     noteId: "nhser-note",
-    color: "rgba(55, 65, 81, 0.85)",
-    widthBase: 1.5,
     enabledIn: ["all", "england"],
     disabledNote: "England only",
   },
   icb: {
-    sourceId: "icb-boundaries-source",
-    layerId: "icb-boundaries-layer",
-    sourceLayerBase: "public.icb_tiles_2023",
     toggleId: "icb-toggle",
     groupId: "icb-toggle-group",
     noteId: "icb-note",
-    color: "rgba(127, 29, 29, 0.82)",
-    widthBase: 1.25,
     enabledIn: ["all", "england"],
     disabledNote: "England only",
   },
   lhb: {
-    sourceId: "lhb-boundaries-source",
-    layerId: "lhb-boundaries-layer",
-    sourceLayerBase: "public.lhb_tiles_2022",
     toggleId: "lhb-toggle",
     groupId: "lhb-toggle-group",
     noteId: "lhb-note",
-    color: "rgba(22, 101, 52, 0.78)",
-    widthBase: 1.4,
     enabledIn: ["all", "wales"],
     disabledNote: "Wales only",
   },
 };
 
-// Returns the tile era to actually request for the given nation selection.
-// Only England solo respects the era toggle; everything else uses 2011.
-function effectiveEra(nation) {
-  return nation === "england" ? currentEra : "2011";
+function isHealthBoundaryEnabledForCurrentNation(config) {
+  return config.enabledIn.includes(currentNation);
 }
 
-function getViewName(era, zoom) {
-  const zoomSuffix =
-    zoom <= 4 ? "z0_4" : zoom <= 7 ? "z5_7" : zoom <= 10 ? "z8_10" : "z11_14";
-  return `public.uk_master_${era}_${zoomSuffix}`;
-}
+function updateDatasetInfo(selectedNation, era) {
+  const infoEl = document.getElementById("dataset-info");
+  const noteEl = document.getElementById("era-note");
+  const eraGroup = document.getElementById("era-toggle-group");
+  const eraSelect = document.getElementById("era-toggle");
 
-function getHealthBoundaryViewName(sourceLayerBase, zoom) {
-  const zoomSuffix =
-    zoom <= 4 ? "z0_4" : zoom <= 7 ? "z5_7" : zoom <= 10 ? "z8_10" : "z11_14";
-  return `${sourceLayerBase}_${zoomSuffix}`;
-}
+  const LABELS = {
+    england: "England",
+    wales: "Wales",
+    scotland: "Scotland",
+    northern_ireland: "N. Ireland",
+  };
 
-function getLocalAuthorityYearForNation(nation) {
-  if (nation === "england") {
-    return currentNation === "england" && currentEra === "2021" ? 2024 : 2019;
-  }
-  if (nation === "wales") {
-    return 2019;
-  }
-  if (nation === "scotland") {
-    return 2011;
-  }
-  return null;
-}
+  const eraActive = selectedNation === "england";
+  eraGroup.style.opacity = eraActive ? "1" : "0.45";
+  eraSelect.disabled = !eraActive;
+  noteEl.textContent = eraActive
+    ? ""
+    : selectedNation === "all"
+      ? "All UK view uses 2011-era boundaries for all nations"
+      : "Era selector applies to England only";
 
-function getLocalAuthorityFilter() {
-  if (currentNation === "northern_ireland") {
-    return null;
-  }
+  const nations =
+    selectedNation === "all"
+      ? ["england", "wales", "scotland", "northern_ireland"]
+      : [selectedNation];
 
-  if (currentNation === "england") {
-    return [
-      "all",
-      ["==", ["slice", ["get", "lad_code"], 0, 1], "E"],
-      ["==", ["get", "year"], getLocalAuthorityYearForNation("england")],
-    ];
-  }
-
-  if (currentNation === "wales") {
-    return [
-      "all",
-      ["==", ["slice", ["get", "lad_code"], 0, 1], "W"],
-      ["==", ["get", "year"], 2019],
-    ];
-  }
-
-  if (currentNation === "scotland") {
-    return [
-      "all",
-      ["==", ["slice", ["get", "lad_code"], 0, 1], "S"],
-      ["==", ["get", "year"], 2011],
-    ];
-  }
-
-  return [
-    "any",
-    [
-      "all",
-      ["==", ["slice", ["get", "lad_code"], 0, 1], "E"],
-      ["==", ["get", "year"], 2019],
-    ],
-    [
-      "all",
-      ["==", ["slice", ["get", "lad_code"], 0, 1], "W"],
-      ["==", ["get", "year"], 2019],
-    ],
-    [
-      "all",
-      ["==", ["slice", ["get", "lad_code"], 0, 1], "S"],
-      ["==", ["get", "year"], 2011],
-    ],
-  ];
-}
-
-function ensureLocalAuthoritySource() {
-  if (map.getSource(LA_SOURCE_ID)) {
-    return;
-  }
-
-  map.addSource(LA_SOURCE_ID, {
-    type: "vector",
-    tiles: [`${TILES_BASE_URL}/${LA_SOURCE_LAYER}/{z}/{x}/{y}.pbf`],
-    minzoom: 0,
-    maxzoom: 14,
+  const lines = nations.map((n) => {
+    const eraKey =
+      selectedNation === "all" ? "2011" : n === "england" ? era : "2011";
+    const d = DATASET_INFO[n][eraKey];
+    const noteStr = d.note
+      ? ` <span style="color:#9a6700;font-style:italic;">(${d.note})</span>`
+      : "";
+    return `<div><strong>${LABELS[n]}:</strong> ${d.imd} &middot; ${d.boundaries}${noteStr}</div>`;
   });
-}
 
-function removeLocalAuthorityLayer() {
-  if (map.getLayer(LA_LAYER_ID)) {
-    map.removeLayer(LA_LAYER_ID);
-  }
-}
-
-function updateLocalAuthorityLayer() {
-  const laToggle = document.getElementById("la-toggle");
-  const requested = !!laToggle?.checked;
-
-  if (!requested || currentNation === "northern_ireland") {
-    removeLocalAuthorityLayer();
-    return;
-  }
-
-  ensureLocalAuthoritySource();
-
-  if (!map.getLayer(LA_LAYER_ID)) {
-    map.addLayer({
-      id: LA_LAYER_ID,
-      type: "line",
-      source: LA_SOURCE_ID,
-      "source-layer": LA_SOURCE_LAYER,
-      paint: {
-        "line-color": "rgba(55, 65, 81, 0.55)",
-        "line-width": [
-          "interpolate",
-          ["linear"],
-          ["zoom"],
-          4,
-          0.6,
-          7,
-          1.1,
-          10,
-          1.8,
-        ],
-        "line-opacity": 1,
-      },
-    });
-  }
-
-  // Keep LA boundaries above the deprivation fill layer after source/layer swaps.
-  map.moveLayer(LA_LAYER_ID);
-
-  const laFilter = getLocalAuthorityFilter();
-  if (laFilter) {
-    map.setFilter(LA_LAYER_ID, laFilter);
-  } else {
-    removeLocalAuthorityLayer();
-  }
+  infoEl.innerHTML = lines.join("");
 }
 
 function updateLocalAuthorityControlState() {
@@ -299,84 +142,6 @@ function updateLocalAuthorityControlState() {
     : "Not available for Northern Ireland in this layer";
 }
 
-function isHealthBoundaryEnabledForCurrentNation(config) {
-  return config.enabledIn.includes(currentNation);
-}
-
-function ensureHealthBoundarySource(config) {
-  const sourceLayer = getHealthBoundaryViewName(
-    config.sourceLayerBase,
-    map.getZoom(),
-  );
-
-  if (map.getLayer(config.layerId)) {
-    map.removeLayer(config.layerId);
-  }
-
-  if (map.getSource(config.sourceId)) {
-    map.removeSource(config.sourceId);
-  }
-
-  map.addSource(config.sourceId, {
-    type: "vector",
-    tiles: [`${TILES_BASE_URL}/${sourceLayer}/{z}/{x}/{y}.pbf`],
-    minzoom: 0,
-    maxzoom: 14,
-  });
-
-  return sourceLayer;
-}
-
-function removeHealthBoundaryLayer(config) {
-  if (map.getLayer(config.layerId)) {
-    map.removeLayer(config.layerId);
-  }
-}
-
-function updateHealthBoundaryLayer(boundaryKey) {
-  const config = HEALTH_BOUNDARIES[boundaryKey];
-  const toggle = document.getElementById(config.toggleId);
-  const requested = !!toggle?.checked;
-  const enabled = isHealthBoundaryEnabledForCurrentNation(config);
-
-  if (!requested || !enabled) {
-    removeHealthBoundaryLayer(config);
-    return;
-  }
-
-  const sourceLayer = ensureHealthBoundarySource(config);
-
-  if (!map.getLayer(config.layerId)) {
-    map.addLayer({
-      id: config.layerId,
-      type: "line",
-      source: config.sourceId,
-      "source-layer": sourceLayer,
-      paint: {
-        "line-color": config.color,
-        "line-width": [
-          "interpolate",
-          ["linear"],
-          ["zoom"],
-          4,
-          config.widthBase * 0.6,
-          7,
-          config.widthBase,
-          10,
-          config.widthBase * 1.4,
-        ],
-        "line-opacity": 1,
-      },
-    });
-  }
-
-  map.moveLayer(config.layerId);
-}
-
-function updateHealthBoundaryLayers() {
-  Object.keys(HEALTH_BOUNDARIES).forEach(updateHealthBoundaryLayer);
-}
-
 function updateHealthBoundaryControlState() {
   Object.values(HEALTH_BOUNDARIES).forEach((config) => {
     const toggle = document.getElementById(config.toggleId);
@@ -388,431 +153,246 @@ function updateHealthBoundaryControlState() {
     toggle.disabled = !enabled;
     group.style.opacity = enabled ? "1" : "0.45";
     note.textContent = enabled ? "" : config.disabledNote;
+
+    if (!enabled && toggle.checked) {
+      toggle.checked = false;
+    }
   });
 }
 
-function getColorExpression() {
+function applyOverlayVisibility() {
+  if (!mapInstance) return;
+
+  const localAuthorityEnabled =
+    currentNation !== "northern_ireland" &&
+    !!document.getElementById("la-toggle")?.checked;
+
+  const nhserEnabled =
+    isHealthBoundaryEnabledForCurrentNation(HEALTH_BOUNDARIES.nhser) &&
+    !!document.getElementById("nhser-toggle")?.checked;
+
+  const icbEnabled =
+    isHealthBoundaryEnabledForCurrentNation(HEALTH_BOUNDARIES.icb) &&
+    !!document.getElementById("icb-toggle")?.checked;
+
+  const lhbEnabled =
+    isHealthBoundaryEnabledForCurrentNation(HEALTH_BOUNDARIES.lhb) &&
+    !!document.getElementById("lhb-toggle")?.checked;
+
+  mapInstance.setOverlayVisibility({
+    localAuthority: localAuthorityEnabled,
+    nhser: nhserEnabled,
+    icb: icbEnabled,
+    lhb: lhbEnabled,
+  });
+}
+
+function normalizeNation(nationText) {
+  return String(nationText || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_");
+}
+
+function shouldShowTooltipRowForNation(rowKey, nation) {
+  if (rowKey === "nhser" || rowKey === "icb") return nation === "england";
+  if (rowKey === "lhb") return nation === "wales";
+  if (rowKey === "lad") {
+    return nation === "england" || nation === "wales" || nation === "scotland";
+  }
+  return true;
+}
+
+function getBoundaryTypeLabelForNation(nation) {
+  if (nation === "scotland") return "Data Zones";
+  if (nation === "northern_ireland") return "SOAs";
+  return "LSOAs";
+}
+
+function isMeaningfulTooltipValue(value) {
+  const compact = String(value || "")
+    .replace(/\s+/g, "")
+    .trim();
+  if (!compact) return false;
+  return !/^[-–()]+$/.test(compact);
+}
+
+function postProcessTooltipRows(rootEl) {
+  const popups = rootEl.querySelectorAll(".maplibregl-popup-content");
+  popups.forEach((popupEl) => {
+    const nationEl = popupEl.querySelector("[data-tooltip-nation]");
+    const nation = normalizeNation(nationEl?.textContent || "");
+    const boundaryLabelEl = popupEl.querySelector(
+      "[data-tooltip-boundary-label]",
+    );
+
+    if (boundaryLabelEl) {
+      boundaryLabelEl.textContent = `${getBoundaryTypeLabelForNation(nation)}:`;
+    }
+
+    const conditionalRows = popupEl.querySelectorAll("[data-tooltip-row]");
+
+    conditionalRows.forEach((rowEl) => {
+      const rowKey = rowEl.getAttribute("data-tooltip-row") || "";
+      const valueEl = rowEl.querySelector("[data-tooltip-value]");
+      const valueText = valueEl?.textContent || "";
+      const showForNation = shouldShowTooltipRowForNation(rowKey, nation);
+      const hasValue = isMeaningfulTooltipValue(valueText);
+      rowEl.style.display = showForNation && hasValue ? "block" : "none";
+    });
+  });
+}
+
+let tooltipPostProcessScheduled = false;
+
+function scheduleTooltipPostProcessor() {
+  if (tooltipPostProcessScheduled) return;
+
+  tooltipPostProcessScheduled = true;
+  window.requestAnimationFrame(() => {
+    tooltipPostProcessScheduled = false;
+    const mapEl = document.getElementById("map");
+    if (!mapEl) return;
+    postProcessTooltipRows(mapEl);
+  });
+}
+
+function installTooltipPostProcessor() {
+  const mapEl = document.getElementById("map");
+  if (!mapEl) return;
+
+  mapEl.addEventListener("mousemove", scheduleTooltipPostProcessor, {
+    passive: true,
+  });
+
+  mapEl.addEventListener("mouseenter", scheduleTooltipPostProcessor, {
+    passive: true,
+  });
+
+  scheduleTooltipPostProcessor();
+}
+
+function getTooltipTemplate() {
   return [
-    "case",
-    ["==", ["get", "imd_decile"], 0],
-    "#cccccc", // No data
-
-    // England - Reds (darkest = most deprived)
-    ["==", ["get", "nation"], "england"],
-    [
-      "interpolate",
-      ["linear"],
-      ["get", "imd_decile"],
-      1,
-      "#67000d", // Dark red
-      3,
-      "#a50f15",
-      5,
-      "#ef3b2c",
-      7,
-      "#fb6a4a",
-      10,
-      "#fee5d9", // Light red
-    ],
-
-    // Scotland - Blues
-    ["==", ["get", "nation"], "scotland"],
-    [
-      "interpolate",
-      ["linear"],
-      ["get", "imd_decile"],
-      1,
-      "#08306b", // Dark blue
-      3,
-      "#2171b5",
-      5,
-      "#6baed6",
-      7,
-      "#bdd7e7",
-      10,
-      "#eff3ff", // Light blue
-    ],
-
-    // Wales - Greens
-    ["==", ["get", "nation"], "wales"],
-    [
-      "interpolate",
-      ["linear"],
-      ["get", "imd_decile"],
-      1,
-      "#00441b", // Dark green
-      3,
-      "#238b45",
-      5,
-      "#74c476",
-      7,
-      "#bae4b3",
-      10,
-      "#edf8e9", // Light green
-    ],
-
-    // Northern Ireland - Yellows/Oranges
-    ["==", ["get", "nation"], "northern_ireland"],
-    [
-      "interpolate",
-      ["linear"],
-      ["get", "imd_decile"],
-      1,
-      "#7f2704", // Dark orange
-      3,
-      "#d94801",
-      5,
-      "#fd8d3c",
-      7,
-      "#fdbe85",
-      10,
-      "#feedde", // Light yellow
-    ],
-
-    // Fallback
-    "#cccccc",
-  ];
+    '<strong style="display:block;margin-bottom:3px;">{{areaName}}</strong>',
+    '<span data-tooltip-nation style="display:none;">{{nation}}</span>',
+    "<div><strong>Code:</strong> {{areaCode}}</div>",
+    "<div><strong>Decile:</strong> {{imdDecile}}</div>",
+    "<div><strong>Nation:</strong> {{nation}}</div>",
+    "<div><strong data-tooltip-boundary-label>LSOAs:</strong> {{boundaryYear}}</div>",
+    "<div><strong>Index Year:</strong> {{imdYear}}</div>",
+    '<div data-tooltip-row="lad"><strong>Local Authority:</strong> <span data-tooltip-value>{{laName}} ({{laCode}})</span></div>',
+    '<div data-tooltip-row="lad"><strong>LA Year:</strong> <span data-tooltip-value>{{laYear}}</span></div>',
+    '<div data-tooltip-row="nhser"><strong>NHSER:</strong> <span data-tooltip-value>{{nhserName}} ({{nhserCode}})</span></div>',
+    '<div data-tooltip-row="icb"><strong>ICB:</strong> <span data-tooltip-value>{{icbName}} ({{icbCode}})</span></div>',
+    '<div data-tooltip-row="lhb"><strong>LHB:</strong> <span data-tooltip-value>{{lhbName}} ({{lhbCode}})</span></div>',
+  ].join("");
 }
 
-function updateMapSource() {
-  const newLayer = getViewName(effectiveEra(currentNation), map.getZoom());
-  const newTiles = [`${TILES_BASE_URL}/${newLayer}/{z}/{x}/{y}.pbf`];
-
-  const currentFilter = map.getFilter("deprivation-layer");
-
-  if (map.getLayer("deprivation-layer")) {
-    map.removeLayer("deprivation-layer");
-  }
-  if (map.getSource("deprivation-source")) {
-    map.removeSource("deprivation-source");
+function initMap() {
+  if (
+    !window.RcpchImdMap ||
+    typeof window.RcpchImdMap.createImdMap !== "function"
+  ) {
+    console.error("RcpchImdMap bundle not loaded.");
+    return;
   }
 
-  map.addSource("deprivation-source", {
-    type: "vector",
-    tiles: newTiles,
-    minzoom: 0,
-    maxzoom: 14,
-  });
-
-  map.addLayer({
-    id: "deprivation-layer",
-    type: "fill",
-    source: "deprivation-source",
-    "source-layer": newLayer,
-    paint: {
-      "fill-color": getColorExpression(),
-      "fill-opacity": 0.7,
-      "fill-outline-color": "rgba(255, 255, 255, 0.2)",
+  mapInstance = window.RcpchImdMap.createImdMap({
+    container: "map",
+    tilesBaseUrl: TILES_BASE_URL,
+    initialNation: currentNation,
+    initialEra: currentEra,
+    areaTooltipMode: "template",
+    legendPosition: "bottom-right",
+    legendTitle: "Map layers",
+    showLegend: true,
+    style: {
+      choropleth: {
+        baseColorByNation: {
+          england: "#67000d",
+          scotland: "#08306b",
+          wales: "#00441b",
+          northern_ireland: "#7f2704",
+        },
+      },
+      boundaries: {
+        localAuthorityColor: "#374151",
+        localAuthorityWidth: 1,
+        nhserColor: "#1e40af",
+        nhserWidth: 1.5,
+        icbColor: "#9333ea",
+        icbWidth: 1.25,
+        lhbColor: "#166534",
+        lhbWidth: 1.4,
+      },
+      tooltip: {
+        backgroundColor: "#0d0d58",
+        textColor: "#ffffff",
+        borderColor: "#0d0d58",
+        areaLabel: "Area",
+        decileLabel: "IMD decile",
+        nationLabel: "Nation",
+        areaTooltipText: getTooltipTemplate(),
+      },
+      legend: {
+        width: 250,
+      },
+    },
+    onViewChange(view) {
+      currentNation = view.nation;
+      currentEra = view.era;
+      updateDatasetInfo(currentNation, currentEra);
+      updateLocalAuthorityControlState();
+      updateHealthBoundaryControlState();
+      applyOverlayVisibility();
+    },
+    onWarning(warning) {
+      console.warn("[rcpch-imd-map]", warning.code, warning.message);
     },
   });
 
-  if (currentFilter) {
-    map.setFilter("deprivation-layer", currentFilter);
-  }
-
-  updateLocalAuthorityLayer();
-  updateHealthBoundaryLayers();
-
-  console.log(`Switched to table: ${newLayer}, tiles: ${newTiles[0]}`);
-}
-
-map.on("load", () => {
-  const initialLayer = getViewName(effectiveEra(currentNation), map.getZoom());
-
-  map.addSource("deprivation-source", {
-    type: "vector",
-    tiles: [`${TILES_BASE_URL}/${initialLayer}/{z}/{x}/{y}.pbf`],
-    minzoom: 0,
-    maxzoom: 14,
-  });
-
-  map.addLayer({
-    id: "deprivation-layer",
-    type: "fill",
-    source: "deprivation-source",
-    "source-layer": initialLayer,
-    paint: {
-      "fill-color": getColorExpression(),
-      "fill-opacity": 0.7,
-      "fill-outline-color": "rgba(255, 255, 255, 0.2)",
-    },
-  });
-
-  map.on("zoomend", updateMapSource);
-
+  updateDatasetInfo(currentNation, currentEra);
   updateLocalAuthorityControlState();
-  updateLocalAuthorityLayer();
   updateHealthBoundaryControlState();
-  updateHealthBoundaryLayers();
-
-  const popup = new maplibregl.Popup({
-    closeButton: false,
-    closeOnClick: false,
-  });
-
-  map.on("mousemove", "deprivation-layer", (e) => {
-    map.getCanvas().style.cursor = "pointer";
-
-    const feature = e.features[0];
-    const props = feature.properties;
-
-    const decile = getPropCaseInsensitive(props, ["imd_decile"]);
-    const nation = getPropCaseInsensitive(props, ["nation"]);
-    const areaName =
-      getPropCaseInsensitive(props, [
-        "area_name",
-        "areaname",
-        "name",
-        "lsoa_name",
-        "data_zone_name",
-        "soa_name",
-      ]) || "Unknown area";
-    const areaCode =
-      getPropCaseInsensitive(props, [
-        "code",
-        "lsoa_code",
-        "data_zone_code",
-        "soa_code",
-      ]) || "Unknown code";
-    const imdYear = getPropCaseInsensitive(props, ["imd_year", "year"]);
-    const localAuthorityCode = getPropCaseInsensitive(props, [
-      "la_code",
-      "lad_code",
-      "local_authority_code",
-      "local_authority_district_code",
-    ]);
-    const localAuthorityName = getPropCaseInsensitive(props, [
-      "la_name",
-      "lad_name",
-      "local_authority_name",
-      "local_authority_district_name",
-    ]);
-    const localAuthorityYear = getPropCaseInsensitive(props, [
-      "la_year",
-      "lad_year",
-      "local_authority_year",
-      "local_authority_district_year",
-    ]);
-    const nhserCode = getPropCaseInsensitive(props, [
-      "nhser_code",
-      "nhs_region_code",
-      "nhser21cd",
-    ]);
-    const nhserName = getPropCaseInsensitive(props, [
-      "nhser_name",
-      "nhs_region_name",
-      "nhser21nm",
-    ]);
-    const icbCode = getPropCaseInsensitive(props, ["icb_code", "icb23cd"]);
-    const icbName = getPropCaseInsensitive(props, ["icb_name", "icb23nm"]);
-    const lhbCode = getPropCaseInsensitive(props, ["lhb_code", "lhb22cd"]);
-    const lhbName = getPropCaseInsensitive(props, ["lhb_name", "lhb22nm"]);
-
-    const areaLabel = nation
-      ? `${String(nation).replace(/_/g, " ").toUpperCase()}`
-      : "Area";
-
-    // Look up the canonical boundary and IMD descriptions from DATASET_INFO
-    // so the tooltip always reflects the actual dataset for each nation,
-    // not just the raw era key (which would show "2011" for NI instead of "2001 SOAs").
-    const eraKey = effectiveEra(nation);
-    const datasetEntry =
-      nation && DATASET_INFO[nation] && DATASET_INFO[nation][eraKey]
-        ? DATASET_INFO[nation][eraKey]
-        : null;
-    const boundariesLabel = datasetEntry ? datasetEntry.boundaries : eraKey;
-    const imdLabel = datasetEntry ? datasetEntry.imd : (imdYear ?? "Unknown");
-    const localAuthorityLine =
-      nation === "northern_ireland"
-        ? "<div><strong>Local Government District:</strong> Not currently mapped in this layer</div>"
-        : `
-          <div><strong>Local Authority Name:</strong> ${localAuthorityName || "Unknown"}</div>
-          <div><strong>Local Authority Code:</strong> ${localAuthorityCode || "Unknown"}</div>
-          <div><strong>Local Authority Year:</strong> ${localAuthorityYear || "Unknown"}</div>
-        `;
-    const healthBoundaryLine =
-      nation === "england"
-        ? `
-          <div><strong>NHS England Region:</strong> ${nhserName || "Not currently mapped in this layer"}</div>
-          <div><strong>NHS England Region Code:</strong> ${nhserCode || "Unknown"}</div>
-          <div><strong>Integrated Care Board:</strong> ${icbName || "Not currently mapped in this layer"}</div>
-          <div><strong>Integrated Care Board Code:</strong> ${icbCode || "Unknown"}</div>
-        `
-        : nation === "wales"
-          ? `
-            <div><strong>Local Health Board:</strong> ${lhbName || "Not currently mapped in this layer"}</div>
-            <div><strong>Local Health Board Code:</strong> ${lhbCode || "Unknown"}</div>
-          `
-          : "";
-
-    const content = `
-      <div style="padding: 5px;">
-        <strong style="display: block; margin-bottom: 5px; border-bottom: 1px solid #ccc;">
-          ${areaLabel}
-        </strong>
-        <div><strong>Name:</strong> ${areaName}</div>
-        <div><strong>Code:</strong> ${areaCode}</div>
-        ${localAuthorityLine}
-        ${healthBoundaryLine}
-        <div><strong>Decile:</strong> ${decile === 0 ? "No Data" : decile}</div>
-        <div style="margin-top: 5px; font-size: 0.8em; color: #666;">
-          Boundaries: ${boundariesLabel} | Index: ${imdLabel}
-        </div>
-      </div>
-    `;
-
-    popup.setLngLat(e.lngLat).setHTML(content).addTo(map);
-  });
-
-  map.on("mouseleave", "deprivation-layer", () => {
-    map.getCanvas().style.cursor = "";
-    popup.remove();
-  });
-});
-
-function updateDatasetInfo(selectedNation, era) {
-  const infoEl = document.getElementById("dataset-info");
-  const noteEl = document.getElementById("era-note");
-  const eraGroup = document.getElementById("era-toggle-group");
-  const eraSelect = document.getElementById("era-toggle");
-
-  const LABELS = {
-    england: "England",
-    wales: "Wales",
-    scotland: "Scotland",
-    northern_ireland: "N. Ireland",
-  };
-
-  // Era toggle is only meaningful when England is the sole selected nation.
-  const eraActive = selectedNation === "england";
-  eraGroup.style.opacity = eraActive ? "1" : "0.45";
-  eraSelect.disabled = !eraActive;
-  noteEl.textContent = eraActive
-    ? ""
-    : selectedNation === "all"
-      ? "All UK always shows latest data per country"
-      : "Era selector applies to England only";
-
-  const nations =
-    selectedNation === "all"
-      ? ["england", "wales", "scotland", "northern_ireland"]
-      : [selectedNation];
-
-  const lines = nations.map((n) => {
-    // England uses chosen era; all others are fixed on 2011.
-    const eraKey = n === "england" ? era : "2011";
-    const d = DATASET_INFO[n][eraKey];
-    const noteStr = d.note
-      ? ` <span style="color:#9a6700;font-style:italic;">(${d.note})</span>`
-      : "";
-    return `<div><strong>${LABELS[n]}:</strong> ${d.imd} &middot; ${d.boundaries}${noteStr}</div>`;
-  });
-
-  infoEl.innerHTML = lines.join("");
+  applyOverlayVisibility();
+  installTooltipPostProcessor();
 }
 
 document.getElementById("era-toggle").addEventListener("change", (e) => {
   currentEra = e.target.value;
-  updateMapSource();
+  if (!mapInstance) return;
+  mapInstance.setEra(currentEra);
   updateDatasetInfo(currentNation, currentEra);
   updateLocalAuthorityControlState();
-  updateLocalAuthorityLayer();
   updateHealthBoundaryControlState();
-  updateHealthBoundaryLayers();
+  applyOverlayVisibility();
 });
 
 document.getElementById("nation-filter").addEventListener("change", (e) => {
   currentNation = e.target.value;
-  const selectedNation = currentNation;
-  map.setFilter(
-    "deprivation-layer",
-    selectedNation === "all" ? null : ["==", ["get", "nation"], selectedNation],
-  );
-  // Changing nation may change the effective era (England→2021, others→2011)
-  updateMapSource();
-  updateLegend(selectedNation);
-  updateDatasetInfo(selectedNation, currentEra);
+  if (!mapInstance) return;
+  mapInstance.setNation(currentNation);
+  updateDatasetInfo(currentNation, currentEra);
   updateLocalAuthorityControlState();
-  updateLocalAuthorityLayer();
   updateHealthBoundaryControlState();
-  updateHealthBoundaryLayers();
+  applyOverlayVisibility();
 });
 
-document.getElementById("la-toggle").addEventListener("change", (e) => {
-  updateLocalAuthorityLayer();
+document.getElementById("la-toggle").addEventListener("change", () => {
+  applyOverlayVisibility();
 });
 
 document.getElementById("nhser-toggle").addEventListener("change", () => {
-  updateHealthBoundaryLayer("nhser");
+  applyOverlayVisibility();
 });
 
 document.getElementById("icb-toggle").addEventListener("change", () => {
-  updateHealthBoundaryLayer("icb");
+  applyOverlayVisibility();
 });
 
 document.getElementById("lhb-toggle").addEventListener("change", () => {
-  updateHealthBoundaryLayer("lhb");
+  applyOverlayVisibility();
 });
 
-function updateLegend(nation) {
-  const legendScale = document.querySelector(".legend-scale");
-
-  let colors, title;
-
-  if (nation === "all") {
-    title = "Deprivation Decile (All Nations)";
-    legendScale.innerHTML = `
-      <div class="legend-item"><div class="color-box" style="background: #67000d;"></div> England - Most Deprived</div>
-      <div class="legend-item"><div class="color-box" style="background: #08306b;"></div> Scotland - Most Deprived</div>
-      <div class="legend-item"><div class="color-box" style="background: #00441b;"></div> Wales - Most Deprived</div>
-      <div class="legend-item"><div class="color-box" style="background: #7f2704;"></div> N. Ireland - Most Deprived</div>
-      <div class="legend-item"><div class="color-box" style="background: #cccccc;"></div> No Data</div>
-    `;
-  } else if (nation === "england") {
-    title = "England Deprivation Decile";
-    legendScale.innerHTML = `
-      <div class="legend-item"><div class="color-box" style="background: #67000d;"></div> 1 (Most Deprived)</div>
-      <div class="legend-item"><div class="color-box" style="background: #a50f15;"></div> 3</div>
-      <div class="legend-item"><div class="color-box" style="background: #ef3b2c;"></div> 5</div>
-      <div class="legend-item"><div class="color-box" style="background: #fb6a4a;"></div> 7</div>
-      <div class="legend-item"><div class="color-box" style="background: #fee5d9;"></div> 10 (Least Deprived)</div>
-      <div class="legend-item"><div class="color-box" style="background: #cccccc;"></div> No Data</div>
-    `;
-  } else if (nation === "scotland") {
-    title = "Scotland Deprivation Decile";
-    legendScale.innerHTML = `
-      <div class="legend-item"><div class="color-box" style="background: #08306b;"></div> 1 (Most Deprived)</div>
-      <div class="legend-item"><div class="color-box" style="background: #2171b5;"></div> 3</div>
-      <div class="legend-item"><div class="color-box" style="background: #6baed6;"></div> 5</div>
-      <div class="legend-item"><div class="color-box" style="background: #bdd7e7;"></div> 7</div>
-      <div class="legend-item"><div class="color-box" style="background: #eff3ff;"></div> 10 (Least Deprived)</div>
-      <div class="legend-item"><div class="color-box" style="background: #cccccc;"></div> No Data</div>
-    `;
-  } else if (nation === "wales") {
-    title = "Wales Deprivation Decile";
-    legendScale.innerHTML = `
-      <div class="legend-item"><div class="color-box" style="background: #00441b;"></div> 1 (Most Deprived)</div>
-      <div class="legend-item"><div class="color-box" style="background: #238b45;"></div> 3</div>
-      <div class="legend-item"><div class="color-box" style="background: #74c476;"></div> 5</div>
-      <div class="legend-item"><div class="color-box" style="background: #bae4b3;"></div> 7</div>
-      <div class="legend-item"><div class="color-box" style="background: #edf8e9;"></div> 10 (Least Deprived)</div>
-      <div class="legend-item"><div class="color-box" style="background: #cccccc;"></div> No Data</div>
-    `;
-  } else if (nation === "northern_ireland") {
-    title = "Northern Ireland Deprivation Decile";
-    legendScale.innerHTML = `
-      <div class="legend-item"><div class="color-box" style="background: #7f2704;"></div> 1 (Most Deprived)</div>
-      <div class="legend-item"><div class="color-box" style="background: #d94801;"></div> 3</div>
-      <div class="legend-item"><div class="color-box" style="background: #fd8d3c;"></div> 5</div>
-      <div class="legend-item"><div class="color-box" style="background: #fdbe85;"></div> 7</div>
-      <div class="legend-item"><div class="color-box" style="background: #feedde;"></div> 10 (Least Deprived)</div>
-      <div class="legend-item"><div class="color-box" style="background: #cccccc;"></div> No Data</div>
-    `;
-  }
-
-  document.querySelector(".legend-title").textContent = title;
-}
-
-// Initialize legend and dataset info panel
-updateLegend("all");
-updateDatasetInfo("all", currentEra);
+initMap();


### PR DESCRIPTION
## Summary

Replaces the hand-rolled MapLibre implementation in `site/` with the
`@rcpch/imd-map` CDN library, and extends the post-processing pipeline
with additional geometry simplification and health region zoom layers.

## Changes

### Map frontend (`site/`)

- **Removed** bespoke MapLibre JS initialisation, static legend HTML,
  and legend CSS from `index.html` and `map-logic.js`
- **Added** `@rcpch/imd-map@0.1.2` via jsDelivr CDN with SRI integrity
  hash; comment in `index.html` documents how to regenerate hash on
  version bump
- **Rewrote** `map-logic.js` around `RcpchImdMap.createImdMap()`:
  - Nation-aware tooltip post-processing (NHSER/ICB England-only, LHB
    Wales-only, LAD England/Wales/Scotland only)
  - Correct boundary-type label per nation (LSOAs / Data Zones / SOAs)
  - Tooltip post-processor uses `requestAnimationFrame` (fixes page
    freeze caused by MutationObserver feedback loop in earlier draft)
  - Dataset info panel uses correct 2011-era keys for all nations in
    all-UK mode; era-note wording corrected

### Geometry post-processing (`seed.py`)

- **Optimised** `z8_10` simplification tolerance for better
  performance at mid-zoom without visual degradation
- **Added** materialized tile tables for health region boundaries
  (NHS England Regions, ICBs, Local Health Boards) at all zoom tiers,
  served directly by pg_tileserv alongside the existing LSOA/master
  tables

### Bug fixes

- `DROP VIEW IF EXISTS` in post-processing SQL replaced with PL/pgSQL
  `DO $$` blocks that inspect `pg_class.relkind` and issue the correct
  `DROP` statement, preventing "is not a view" errors when objects
  exist as tables

## Testing

- Verified locally: no HTTP 500s, no console errors, smooth tile
  loading across all nations and zoom levels
- All existing pytest tests pass

## Checklist

- [ ] `process_geometries` run against local DB after SQL changes
- [ ] pg_tileserv metadata endpoints verified for new zoom-tier tables
- [ ] SRI hash in `index.html` matches published CDN asset
- [ ] AGENTS.md tile-table inventory updated if new tables added