### PR TITLE
feat: add zoom-tiered local authority tiles and scoped geometry rebuilds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ The platform has two distinct data phases:
   - Generates simplified geometries for low/medium zoom
   - Builds spatial indexes and clusters
   - Materializes tile-serving tables for all zoom tiers
-- `process_geometries` runs post-processing only (no boundary re-download), useful for SQL/view/table-shape changes.
+- `process_geometries` runs post-processing only (no boundary re-download), useful for SQL/view/table-shape changes. Accepts an optional `--layers` flag to process only specific overlay groups (see below).
 
 ## Tile-serving model
 
@@ -128,6 +128,29 @@ No full reseed required:
 Use:
 
 - `python manage.py seed --mode process_geometries`
+
+  To rebuild only specific overlay tables (much faster — minutes not hours):
+
+  ```bash
+  # Local authority tiles only
+  python manage.py seed --mode process_geometries --layers local-authorities
+
+  # All health boundaries (NHSER + ICB + LHB)
+  python manage.py seed --mode process_geometries --layers health-geographies
+
+  # Individual health boundary types
+  python manage.py seed --mode process_geometries --layers nhs-regions
+  python manage.py seed --mode process_geometries --layers integrated-care-boards
+  python manage.py seed --mode process_geometries --layers local-health-boards
+
+  # LSOAs + UK master tiles only
+  python manage.py seed --mode process_geometries --layers lsoas
+
+  # Multiple groups at once
+  python manage.py seed --mode process_geometries --layers local-authorities nhs-regions
+  ```
+
+  **Note**: Section 1 (schema `ADD COLUMN IF NOT EXISTS`) always runs regardless of `--layers` since it is idempotent and fast. `--layers` only gates the expensive UPDATE/CREATE operations.
 
 Full/base reseed likely required:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,11 @@ Use:
 
   **Note**: Section 1 (schema `ADD COLUMN IF NOT EXISTS`) always runs regardless of `--layers` since it is idempotent and fast. `--layers` only gates the expensive UPDATE/CREATE operations.
 
+  Validation behavior after geometry processing:
+
+  - Full geometry rebuilds (`import_bfc_boundaries`, or `process_geometries` with no `--layers` / `--layers all`) run `test_geometries` in strict mode and fail on missing/empty required boundary tier tables.
+  - Scoped rebuilds (`process_geometries --layers <subset>`) run `test_geometries` in report-only mode for boundary-tier completeness, so operators can process a subset without failing due to unrelated layers not being rebuilt yet.
+
 Full/base reseed likely required:
 
 - New source CSV content for core IMD/reference tables

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ This project is a python 3.11 / Django Rest Framework project providing UK censu
      <img src='https://raw.githubusercontent.com/rcpch/rcpch-census-platform/refs/heads/live/static/images/rcpch-logo-mobile.4d5b446caf9a.svg' alt='RCPCH Logo'>
 </p>
 
+<!--
+Documentation routing note for humans and LLMs:
+- README is intentionally overview-first and avoids operational/detail duplication.
+- Human/operator runbooks live in site/docs/.
+- Agent/LLM-specific operational constraints live in AGENTS.md.
+-->
+
+## Documentation Routing (Humans and LLMs)
+
+Use this file as a high-level entry point.
+
+- For boundary datasets, tile table contracts, and geometry processing details, use [site/docs/boundaries.md](site/docs/boundaries.md).
+- For managed database restore and seeding operations, use [site/docs/managed-database-seeding.md](site/docs/managed-database-seeding.md).
+- For deployment flow and architecture, use [site/docs/deploy.md](site/docs/deploy.md).
+- For coding-agent and LLM operational constraints, use [AGENTS.md](AGENTS.md).
+
+If README content conflicts with site/docs, treat site/docs as the source of truth.
+
 
 ## Why is it needed?
 
@@ -107,7 +125,7 @@ These domains are then weighted and contribute to the final index of multiple de
 
 Written in python 3.11 and django-rest-framework. We recommend using `pyenv` or similar python version manager and virtual environment manager.
 
-### Option One
+### Option One (Quick Local Setup)
 
 1. clone the repo
 2. ```cd rcpch_census_platform```
@@ -115,14 +133,16 @@ Written in python 3.11 and django-rest-framework. We recommend using `pyenv` or 
 4. ```python manage.py createsuperuser --username username --email username@email.com```
 5. ```python manage.py makemigrations```
 6. ```python manage.py migrate```
-7. ```python manage.py seed --mode='__all__'```
-8. ```python manage.py seed --mode='import_bfc_boundaries'```
+7. `python manage.py seed --mode='__all__'`
+8. `python manage.py seed --mode='import_bfc_boundaries'`
 
-This latter step will take more than 30 minutes as it populates the database with all the census and deprivation data, and also the geographical boundary shapes and map tiles. If successful, it should yield the following message:
-> ![alt rcpch-census-db](static/images/census_db_screenshot.png?raw=true)
+Notes:
+
+- `import_bfc_boundaries` can take significant time on a fresh build.
+- For seeding modes, boundary import behavior, and validation semantics, use [site/docs/boundaries.md](site/docs/boundaries.md).
 
 The final step is to run the server:
-```python manage.py runserver```
+`python manage.py runserver`
 
 ## Tests — postcode mocking
 
@@ -161,9 +181,11 @@ Steps:
     - `./s/dev`
     - (equivalent: `docker compose -f docker-compose-postgis.yml up --build`)
 3. The `web` container will wait for the database, run `collectstatic`, run `migrate`, and then start Django.
-4. Seed the database (this can take a long time):
+4. Seed the database:
     - `docker compose -f docker-compose-postgis.yml exec web python manage.py seed --mode='__all__'`
-    - Optional: `docker compose -f docker-compose-postgis.yml exec web python manage.py seed --mode='import_bfc_boundaries'`
+    - Then: `docker compose -f docker-compose-postgis.yml exec web python manage.py seed --mode='import_bfc_boundaries'`
+
+For full seeding guidance (including partial geometry rebuild behavior and validation modes), use [site/docs/boundaries.md](site/docs/boundaries.md).
 
 Useful URLs:
 
@@ -186,32 +208,14 @@ To point it at a deployed tiles endpoint, pass a query parameter:
 
 - `?tilesBase=https://<your-host>/tiles`
 
-### Other Command Line functions
+### Seeding and Validation Commands
 
-The seeding process should skip for each model that has the correct number of rows.
+Useful commands:
 
-These are:
+- `python manage.py seed --mode test_table_totals`
+- `python manage.py seed --mode test_geometries`
 
-| Model | Number of Rows | Notes | 
-|----|----|----|
-| LSOA (2011) | 34,753 | 2011 LSOA rows (32,844 in England, 1,909 in Wales). |
-| LSOA (2021) | 35,672 | 2021 LSOA rows. |
-| DataZone | 6,976 | Scotland Data Zones. |
-| LocalAuthority (2011) | 32 | Scotland local authorities (2011). |
-| LocalAuthority (2019) | 339 | England + Wales local authorities (2019): 317 + 22. |
-| LocalAuthority (2024, with geom) | 318 | 2024 local authorities with geometries present. |
-| PopulationDensity | 32,844 | England population densities. |
-| GreenSpace | 371 | England/Wales/Scotland green space rows. |
-| SOA | 890 | Northern Ireland SOAs. |
-| WelshIndexMultipleDeprivation | 1,909 | Wales WIMD (2019) rows. |
-| NorthernIrelandIndexMultipleDeprivation | 890 | Northern Ireland NIMDM (2017) rows. |
-| ScottishIndexMultipleDeprivation | 6,976 | Scotland SIMD (2020) rows. |
-
-`python manage.py seed --mode test_table_totals`
-
-To validate the generated UK master views have geometries for all nations (and sanity-check the coordinate system), run:
-
-`python manage.py seed --mode test_geometries`
+For expected counts, boundary tier validation behavior, and operational interpretation of these checks, use [site/docs/boundaries.md](site/docs/boundaries.md).
 
 <!-- TODO: #14 #13 remove all references to auth, logins, or tokens in the census engine readme -->
 

--- a/deprivation_scores/management/commands/seed.py
+++ b/deprivation_scores/management/commands/seed.py
@@ -1303,7 +1303,7 @@ class Command(BaseCommand):
             except Exception as e:
                 self.stdout.write(f"    ⚠️ Could not warm zoom {z}: {e}")
 
-    def test_geometries(self):
+    def test_geometries(self, strict=True):
         """
         Test to ensure that the spatial data and views are correctly set up.
         """
@@ -1386,7 +1386,9 @@ class Command(BaseCommand):
                 )
 
             # 4. Boundary tile tier verification
-            self.stdout.write("Checking boundary tier tables (z0_4, z5_7, z8_10, z11_14)...")
+            self.stdout.write(
+                "Checking boundary tier tables (z0_4, z5_7, z8_10, z11_14)..."
+            )
             tiered_boundaries = {
                 "Local Authorities": "la_tiles",
                 "NHS Regions": "nhser_tiles_2021",
@@ -1416,14 +1418,17 @@ class Command(BaseCommand):
                     else:
                         status = "✅"
 
-                    self.stdout.write(
-                        f"  {status} {label} {tier}: {row_count} rows"
-                    )
+                    self.stdout.write(f"  {status} {label} {tier}: {row_count} rows")
 
             if boundary_failures:
                 failures = "\n  - " + "\n  - ".join(boundary_failures)
-                raise CommandError(
-                    "Boundary tier validation failed:" + failures
+                if strict:
+                    raise CommandError("Boundary tier validation failed:" + failures)
+                self.stdout.write(
+                    self.style.WARNING(
+                        "  ⚠️ Boundary tier validation findings (report-only mode):"
+                        + failures
+                    )
                 )
 
             # 5. Coordinate System Verification
@@ -1652,7 +1657,7 @@ class Command(BaseCommand):
             #     self.warm_cache()
 
             # test that the tables have the correct number of geometries
-            self.test_geometries()
+            self.test_geometries(strict=True)
             return
         if options.get("mode") == "process_geometries":
             layers = options.get("layers")
@@ -1664,11 +1669,12 @@ class Command(BaseCommand):
                 + "\n"
             )
             self._run_post_processing_sql(layers=layers)
-            self.test_geometries()
+            partial_layers = bool(layers) and "all" not in layers
+            self.test_geometries(strict=not partial_layers)
             return
 
         if options["mode"] == "test_geometries":
-            self.test_geometries()
+            self.test_geometries(strict=True)
             return
 
         if options["mode"] == "add_organisational_areas":

--- a/deprivation_scores/management/commands/seed.py
+++ b/deprivation_scores/management/commands/seed.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
             "is_complete": is_complete,
         }
 
-    def _run_post_processing_sql(self):
+    def _run_post_processing_sql(self, layers=None):
         self.stdout.write(
             self.style.WARNING(
                 "\n🚀 Running high-performance PostGIS optimizations and building UK-wide views..."
@@ -359,10 +359,56 @@ class Command(BaseCommand):
             ANALYZE public.{view_name};
             """
 
-        # --- SQL Statement List ---
+        def get_la_tile_sql(table_name, geom_column):
+            """Create a zoom-banded local authority tile table."""
+            return f"""
+            DROP TABLE IF EXISTS public.{table_name} CASCADE;
+
+            CREATE TABLE public.{table_name} AS
+            SELECT
+                year::int AS year,
+                local_authority_district_code::text AS lad_code,
+                ST_MakeValid(ST_Multi({geom_column}))::geometry(MultiPolygon, 3857) AS geom
+            FROM deprivation_scores_localauthority
+            WHERE {geom_column} IS NOT NULL;
+
+            CREATE INDEX idx_{table_name}_geom ON public.{table_name} USING GIST (geom);
+            ANALYZE public.{table_name};
+            """
+
+        # --- Layer resolution ---
+        _ALL_LAYERS = frozenset(
+            {
+                "lsoas",
+                "local-authorities",
+                "nhs-regions",
+                "integrated-care-boards",
+                "local-health-boards",
+            }
+        )
+        if layers is None or "all" in layers:
+            _active = _ALL_LAYERS
+        else:
+            _active = set(layers)
+            if "health-geographies" in _active:
+                _active.discard("health-geographies")
+                _active |= {
+                    "nhs-regions",
+                    "integrated-care-boards",
+                    "local-health-boards",
+                }
+
+        def want(*names):
+            return any(n in _active for n in names)
+
+        self.stdout.write(
+            self.style.SUCCESS(f"  Active layer groups: {', '.join(sorted(_active))}")
+        )
+
+        # --- SQL Statement List (conditionally built by layer group) ---
 
         sql_statements = [
-            # Section 1: Schema setup
+            # Section 1: Schema setup (always run — ADD COLUMN IF NOT EXISTS is idempotent and fast)
             "ALTER TABLE deprivation_scores_lsoa ADD COLUMN IF NOT EXISTS geom_3857 geometry(MultiPolygon,3857);",
             "ALTER TABLE deprivation_scores_lsoa ADD COLUMN IF NOT EXISTS geom_3857_simp_z0_4 geometry(MultiPolygon,3857);",
             "ALTER TABLE deprivation_scores_lsoa ADD COLUMN IF NOT EXISTS geom_3857_simp_z5_7 geometry(MultiPolygon,3857);",
@@ -376,6 +422,9 @@ class Command(BaseCommand):
             "ALTER TABLE deprivation_scores_soa ADD COLUMN IF NOT EXISTS geom_3857_simp_z5_7 geometry(MultiPolygon,3857);",
             "ALTER TABLE deprivation_scores_soa ADD COLUMN IF NOT EXISTS geom_3857_simp_z8_10 geometry(MultiPolygon,3857);",
             "ALTER TABLE deprivation_scores_localauthority ADD COLUMN IF NOT EXISTS geom_3857 geometry(MultiPolygon,3857);",
+            "ALTER TABLE deprivation_scores_localauthority ADD COLUMN IF NOT EXISTS geom_3857_simp_z0_4 geometry(MultiPolygon,3857);",
+            "ALTER TABLE deprivation_scores_localauthority ADD COLUMN IF NOT EXISTS geom_3857_simp_z5_7 geometry(MultiPolygon,3857);",
+            "ALTER TABLE deprivation_scores_localauthority ADD COLUMN IF NOT EXISTS geom_3857_simp_z8_10 geometry(MultiPolygon,3857);",
             "ALTER TABLE deprivation_scores_nhsenglishregion ADD COLUMN IF NOT EXISTS geom_3857 geometry(MultiPolygon,3857);",
             "ALTER TABLE deprivation_scores_nhsenglishregion ADD COLUMN IF NOT EXISTS geom_3857_simp_z0_4 geometry(MultiPolygon,3857);",
             "ALTER TABLE deprivation_scores_nhsenglishregion ADD COLUMN IF NOT EXISTS geom_3857_simp_z5_7 geometry(MultiPolygon,3857);",
@@ -388,20 +437,31 @@ class Command(BaseCommand):
             "ALTER TABLE deprivation_scores_localhealthboard ADD COLUMN IF NOT EXISTS geom_3857_simp_z0_4 geometry(MultiPolygon,3857);",
             "ALTER TABLE deprivation_scores_localhealthboard ADD COLUMN IF NOT EXISTS geom_3857_simp_z5_7 geometry(MultiPolygon,3857);",
             "ALTER TABLE deprivation_scores_localhealthboard ADD COLUMN IF NOT EXISTS geom_3857_simp_z8_10 geometry(MultiPolygon,3857);",
-            # Section 2: Cleanup
-            "DROP TABLE IF EXISTS public.uk_master_2011_z0_4 CASCADE;",
-            "DROP TABLE IF EXISTS public.uk_master_2011_z5_7 CASCADE;",
-            "DROP TABLE IF EXISTS public.uk_master_2011_z8_10 CASCADE;",
-            "DROP TABLE IF EXISTS public.uk_master_2011_z11_14 CASCADE;",
-            "DROP TABLE IF EXISTS public.uk_master_2021_z0_4 CASCADE;",
-            "DROP TABLE IF EXISTS public.uk_master_2021_z5_7 CASCADE;",
-            "DROP TABLE IF EXISTS public.uk_master_2021_z8_10 CASCADE;",
-            "DROP TABLE IF EXISTS public.uk_master_2021_z11_14 CASCADE;",
-            "DROP TABLE IF EXISTS public.lsoa_tiles_2011_z0_4 CASCADE;",
-            "DROP TABLE IF EXISTS public.lsoa_tiles_2011_z11_14 CASCADE;",
-            "DROP TABLE IF EXISTS public.lsoa_tiles_2021_z11_14 CASCADE;",
-            "DROP TABLE IF EXISTS public.lsoa_tiles_2021_z0_4 CASCADE;",
-            """
+        ]
+
+        # Section 2: Cleanup (conditional per layer group)
+        if want("lsoas"):
+            sql_statements += [
+                "DROP TABLE IF EXISTS public.uk_master_2011_z0_4 CASCADE;",
+                "DROP TABLE IF EXISTS public.uk_master_2011_z5_7 CASCADE;",
+                "DROP TABLE IF EXISTS public.uk_master_2011_z8_10 CASCADE;",
+                "DROP TABLE IF EXISTS public.uk_master_2011_z11_14 CASCADE;",
+                "DROP TABLE IF EXISTS public.uk_master_2021_z0_4 CASCADE;",
+                "DROP TABLE IF EXISTS public.uk_master_2021_z5_7 CASCADE;",
+                "DROP TABLE IF EXISTS public.uk_master_2021_z8_10 CASCADE;",
+                "DROP TABLE IF EXISTS public.uk_master_2021_z11_14 CASCADE;",
+                "DROP TABLE IF EXISTS public.lsoa_tiles_2011_z0_4 CASCADE;",
+                "DROP TABLE IF EXISTS public.lsoa_tiles_2011_z5_7 CASCADE;",
+                "DROP TABLE IF EXISTS public.lsoa_tiles_2011_z8_10 CASCADE;",
+                "DROP TABLE IF EXISTS public.lsoa_tiles_2011_z11_14 CASCADE;",
+                "DROP TABLE IF EXISTS public.lsoa_tiles_2021_z0_4 CASCADE;",
+                "DROP TABLE IF EXISTS public.lsoa_tiles_2021_z5_7 CASCADE;",
+                "DROP TABLE IF EXISTS public.lsoa_tiles_2021_z8_10 CASCADE;",
+                "DROP TABLE IF EXISTS public.lsoa_tiles_2021_z11_14 CASCADE;",
+            ]
+        if want("local-authorities"):
+            sql_statements += [
+                """
             DO $$
             DECLARE
                 relkind_char char;
@@ -420,7 +480,14 @@ class Command(BaseCommand):
                 END IF;
             END $$;
             """,
-            """
+                "DROP TABLE IF EXISTS public.la_tiles_z0_4 CASCADE;",
+                "DROP TABLE IF EXISTS public.la_tiles_z5_7 CASCADE;",
+                "DROP TABLE IF EXISTS public.la_tiles_z8_10 CASCADE;",
+                "DROP TABLE IF EXISTS public.la_tiles_z11_14 CASCADE;",
+            ]
+        if want("nhs-regions"):
+            sql_statements += [
+                """
             DO $$
             DECLARE
                 relkind_char char;
@@ -439,7 +506,14 @@ class Command(BaseCommand):
                 END IF;
             END $$;
             """,
-            """
+                "DROP TABLE IF EXISTS public.nhser_tiles_2021_z0_4 CASCADE;",
+                "DROP TABLE IF EXISTS public.nhser_tiles_2021_z5_7 CASCADE;",
+                "DROP TABLE IF EXISTS public.nhser_tiles_2021_z8_10 CASCADE;",
+                "DROP TABLE IF EXISTS public.nhser_tiles_2021_z11_14 CASCADE;",
+            ]
+        if want("integrated-care-boards"):
+            sql_statements += [
+                """
             DO $$
             DECLARE
                 relkind_char char;
@@ -458,7 +532,14 @@ class Command(BaseCommand):
                 END IF;
             END $$;
             """,
-            """
+                "DROP TABLE IF EXISTS public.icb_tiles_2023_z0_4 CASCADE;",
+                "DROP TABLE IF EXISTS public.icb_tiles_2023_z5_7 CASCADE;",
+                "DROP TABLE IF EXISTS public.icb_tiles_2023_z8_10 CASCADE;",
+                "DROP TABLE IF EXISTS public.icb_tiles_2023_z11_14 CASCADE;",
+            ]
+        if want("local-health-boards"):
+            sql_statements += [
+                """
             DO $$
             DECLARE
                 relkind_char char;
@@ -477,237 +558,332 @@ class Command(BaseCommand):
                 END IF;
             END $$;
             """,
-            "DROP TABLE IF EXISTS public.nhser_tiles_2021_z0_4 CASCADE;",
-            "DROP TABLE IF EXISTS public.nhser_tiles_2021_z5_7 CASCADE;",
-            "DROP TABLE IF EXISTS public.nhser_tiles_2021_z8_10 CASCADE;",
-            "DROP TABLE IF EXISTS public.nhser_tiles_2021_z11_14 CASCADE;",
-            "DROP TABLE IF EXISTS public.icb_tiles_2023_z0_4 CASCADE;",
-            "DROP TABLE IF EXISTS public.icb_tiles_2023_z5_7 CASCADE;",
-            "DROP TABLE IF EXISTS public.icb_tiles_2023_z8_10 CASCADE;",
-            "DROP TABLE IF EXISTS public.icb_tiles_2023_z11_14 CASCADE;",
-            "DROP TABLE IF EXISTS public.lhb_tiles_2022_z0_4 CASCADE;",
-            "DROP TABLE IF EXISTS public.lhb_tiles_2022_z5_7 CASCADE;",
-            "DROP TABLE IF EXISTS public.lhb_tiles_2022_z8_10 CASCADE;",
-            "DROP TABLE IF EXISTS public.lhb_tiles_2022_z11_14 CASCADE;",
-            # Section 3: Geoprocessing (WGS84 -> Web Mercator 3857)
-            "UPDATE deprivation_scores_lsoa SET geom_3857 = ST_MakeValid(geom_3857) WHERE NOT ST_IsValid(geom_3857);",
-            "UPDATE deprivation_scores_lsoa SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
-            "UPDATE deprivation_scores_datazone SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
-            "UPDATE deprivation_scores_soa SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
-            "UPDATE deprivation_scores_localauthority SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
-            "UPDATE deprivation_scores_nhsenglishregion SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
-            "UPDATE deprivation_scores_integratedcareboard SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
-            "UPDATE deprivation_scores_localhealthboard SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
-            # Section 4: Simplification
-            # Compute all simplification tiers in a single pass per table to reduce write overhead.
-            # z0-4: 1,500 m, z5-7: 200 m, z8-10: 60 m (all in EPSG:3857 metres).
-            "UPDATE deprivation_scores_lsoa SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
-            "UPDATE deprivation_scores_datazone SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
-            "UPDATE deprivation_scores_soa SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
-            "UPDATE deprivation_scores_nhsenglishregion SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
-            "UPDATE deprivation_scores_integratedcareboard SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
-            "UPDATE deprivation_scores_localhealthboard SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
-            # Section 5: Spatial indexing & clustering
-            # Raw geometry indexes (for z11+ and raw queries)
-            "CREATE INDEX IF NOT EXISTS idx_lsoa_3857 ON deprivation_scores_lsoa USING GIST (geom_3857);",
-            "CREATE INDEX IF NOT EXISTS idx_datazone_3857 ON deprivation_scores_datazone USING GIST (geom_3857);",
-            "CREATE INDEX IF NOT EXISTS idx_soa_3857 ON deprivation_scores_soa USING GIST (geom_3857);",
-            # Simplified geometry indexes (critical for tile performance)
-            "CREATE INDEX IF NOT EXISTS idx_lsoa_simp_z0_4 ON deprivation_scores_lsoa USING GIST (geom_3857_simp_z0_4);",
-            "CREATE INDEX IF NOT EXISTS idx_lsoa_simp_z5_7 ON deprivation_scores_lsoa USING GIST (geom_3857_simp_z5_7);",
-            "CREATE INDEX IF NOT EXISTS idx_lsoa_simp_z8_10 ON deprivation_scores_lsoa USING GIST (geom_3857_simp_z8_10);",
-            "CREATE INDEX IF NOT EXISTS idx_datazone_simp_z0_4 ON deprivation_scores_datazone USING GIST (geom_3857_simp_z0_4);",
-            "CREATE INDEX IF NOT EXISTS idx_datazone_simp_z5_7 ON deprivation_scores_datazone USING GIST (geom_3857_simp_z5_7);",
-            "CREATE INDEX IF NOT EXISTS idx_datazone_simp_z8_10 ON deprivation_scores_datazone USING GIST (geom_3857_simp_z8_10);",
-            "CREATE INDEX IF NOT EXISTS idx_soa_simp_z0_4 ON deprivation_scores_soa USING GIST (geom_3857_simp_z0_4);",
-            "CREATE INDEX IF NOT EXISTS idx_soa_simp_z5_7 ON deprivation_scores_soa USING GIST (geom_3857_simp_z5_7);",
-            "CREATE INDEX IF NOT EXISTS idx_soa_simp_z8_10 ON deprivation_scores_soa USING GIST (geom_3857_simp_z8_10);",
-            "CREATE INDEX IF NOT EXISTS idx_nhsenglishregion_simp_z0_4 ON deprivation_scores_nhsenglishregion USING GIST (geom_3857_simp_z0_4);",
-            "CREATE INDEX IF NOT EXISTS idx_nhsenglishregion_simp_z5_7 ON deprivation_scores_nhsenglishregion USING GIST (geom_3857_simp_z5_7);",
-            "CREATE INDEX IF NOT EXISTS idx_nhsenglishregion_simp_z8_10 ON deprivation_scores_nhsenglishregion USING GIST (geom_3857_simp_z8_10);",
-            "CREATE INDEX IF NOT EXISTS idx_integratedcareboard_simp_z0_4 ON deprivation_scores_integratedcareboard USING GIST (geom_3857_simp_z0_4);",
-            "CREATE INDEX IF NOT EXISTS idx_integratedcareboard_simp_z5_7 ON deprivation_scores_integratedcareboard USING GIST (geom_3857_simp_z5_7);",
-            "CREATE INDEX IF NOT EXISTS idx_integratedcareboard_simp_z8_10 ON deprivation_scores_integratedcareboard USING GIST (geom_3857_simp_z8_10);",
-            "CREATE INDEX IF NOT EXISTS idx_localhealthboard_simp_z0_4 ON deprivation_scores_localhealthboard USING GIST (geom_3857_simp_z0_4);",
-            "CREATE INDEX IF NOT EXISTS idx_localhealthboard_simp_z5_7 ON deprivation_scores_localhealthboard USING GIST (geom_3857_simp_z5_7);",
-            "CREATE INDEX IF NOT EXISTS idx_localhealthboard_simp_z8_10 ON deprivation_scores_localhealthboard USING GIST (geom_3857_simp_z8_10);",
-            "CREATE INDEX IF NOT EXISTS idx_localauthority_3857 ON deprivation_scores_localauthority USING GIST (geom_3857);",
-            "CREATE INDEX IF NOT EXISTS idx_nhsenglishregion_3857 ON deprivation_scores_nhsenglishregion USING GIST (geom_3857);",
-            "CREATE INDEX IF NOT EXISTS idx_integratedcareboard_3857 ON deprivation_scores_integratedcareboard USING GIST (geom_3857);",
-            "CREATE INDEX IF NOT EXISTS idx_localhealthboard_3857 ON deprivation_scores_localhealthboard USING GIST (geom_3857);",
-            "CREATE INDEX IF NOT EXISTS idx_lsoa_year_id ON deprivation_scores_lsoa (year, id);",
-            "CREATE INDEX IF NOT EXISTS idx_english_imd_year_lsoa ON deprivation_scores_englishindexmultipledeprivation (year, lsoa_id);",
-            "CREATE INDEX IF NOT EXISTS idx_welsh_imd_year_lsoa ON deprivation_scores_welshindexmultipledeprivation (year, lsoa_id);",
-            "CLUSTER deprivation_scores_lsoa USING idx_lsoa_simp_z5_7;",
-            "CLUSTER deprivation_scores_datazone USING idx_datazone_simp_z5_7;",
-            "CLUSTER deprivation_scores_soa USING idx_soa_simp_z5_7;",
-            "CLUSTER deprivation_scores_localauthority USING idx_localauthority_3857;",
-            "CLUSTER deprivation_scores_nhsenglishregion USING idx_nhsenglishregion_simp_z5_7;",
-            "CLUSTER deprivation_scores_integratedcareboard USING idx_integratedcareboard_simp_z5_7;",
-            "CLUSTER deprivation_scores_localhealthboard USING idx_localhealthboard_simp_z5_7;",
-            # Section 6: LSOA Views
-            get_lsoa_view_sql("lsoa_tiles_2011_z0_4", "geom_3857_simp_z0_4", 2011),
-            get_lsoa_view_sql("lsoa_tiles_2011_z5_7", "geom_3857_simp_z5_7", 2011),
-            get_lsoa_view_sql("lsoa_tiles_2011_z8_10", "geom_3857_simp_z8_10", 2011),
-            get_lsoa_view_sql("lsoa_tiles_2021_z0_4", "geom_3857_simp_z0_4", 2021),
-            get_lsoa_view_sql("lsoa_tiles_2021_z5_7", "geom_3857_simp_z5_7", 2021),
-            get_lsoa_view_sql("lsoa_tiles_2021_z8_10", "geom_3857_simp_z8_10", 2021),
-            # z11-14: raw geometry — no simplification, prevents gap artifacts at high zoom
-            get_lsoa_view_sql("lsoa_tiles_2011_z11_14", "geom_3857", 2011),
-            get_lsoa_view_sql("lsoa_tiles_2021_z11_14", "geom_3857", 2021),
-            # Section 7: UK Master Views
-            get_uk_master_view_sql("uk_master_2011_z0_4", "simp_z0_4", 2011, 2019),
-            get_uk_master_view_sql("uk_master_2011_z5_7", "simp_z5_7", 2011, 2019),
-            get_uk_master_view_sql("uk_master_2011_z8_10", "simp_z8_10", 2011, 2019),
-            get_uk_master_view_sql("uk_master_2021_z0_4", "simp_z0_4", 2021, 2025),
-            get_uk_master_view_sql("uk_master_2021_z5_7", "simp_z5_7", 2021, 2025),
-            get_uk_master_view_sql("uk_master_2021_z8_10", "simp_z8_10", 2021, 2025),
-            # z11-14: raw geometry — no simplification, prevents gap artifacts at high zoom
-            get_uk_master_view_sql("uk_master_2011_z11_14", "3857", 2011, 2019),
-            get_uk_master_view_sql("uk_master_2021_z11_14", "3857", 2021, 2025),
-            "CREATE TABLE public.la_tiles AS SELECT year::int AS year, local_authority_district_code::text AS lad_code, ST_MakeValid(ST_Multi(geom_3857))::geometry(MultiPolygon, 3857) AS geom FROM deprivation_scores_localauthority WHERE geom_3857 IS NOT NULL;",
-            "CREATE INDEX idx_la_tiles_geom ON public.la_tiles USING GIST (geom);",
-            "ANALYZE public.la_tiles;",
-            get_health_boundary_view_sql(
-                "nhser_tiles_2021_z0_4",
-                "deprivation_scores_nhsenglishregion",
-                "nhser_code",
-                "nhser_name",
-                2021,
-                "england",
-                "geom_3857_simp_z0_4",
-            ),
-            get_health_boundary_view_sql(
-                "nhser_tiles_2021_z5_7",
-                "deprivation_scores_nhsenglishregion",
-                "nhser_code",
-                "nhser_name",
-                2021,
-                "england",
-                "geom_3857_simp_z5_7",
-            ),
-            get_health_boundary_view_sql(
-                "nhser_tiles_2021_z8_10",
-                "deprivation_scores_nhsenglishregion",
-                "nhser_code",
-                "nhser_name",
-                2021,
-                "england",
-                "geom_3857",
-            ),
-            get_health_boundary_view_sql(
-                "nhser_tiles_2021_z11_14",
-                "deprivation_scores_nhsenglishregion",
-                "nhser_code",
-                "nhser_name",
-                2021,
-                "england",
-                "geom_3857",
-            ),
-            get_health_boundary_view_sql(
-                "icb_tiles_2023_z0_4",
-                "deprivation_scores_integratedcareboard",
-                "icb_code",
-                "icb_name",
-                2023,
-                "england",
-                "geom_3857_simp_z0_4",
-            ),
-            get_health_boundary_view_sql(
-                "icb_tiles_2023_z5_7",
-                "deprivation_scores_integratedcareboard",
-                "icb_code",
-                "icb_name",
-                2023,
-                "england",
-                "geom_3857_simp_z5_7",
-            ),
-            get_health_boundary_view_sql(
-                "icb_tiles_2023_z8_10",
-                "deprivation_scores_integratedcareboard",
-                "icb_code",
-                "icb_name",
-                2023,
-                "england",
-                "geom_3857",
-            ),
-            get_health_boundary_view_sql(
-                "icb_tiles_2023_z11_14",
-                "deprivation_scores_integratedcareboard",
-                "icb_code",
-                "icb_name",
-                2023,
-                "england",
-                "geom_3857",
-            ),
-            get_health_boundary_view_sql(
-                "lhb_tiles_2022_z0_4",
-                "deprivation_scores_localhealthboard",
-                "lhb_code",
-                "lhb_name",
-                2022,
-                "wales",
-                "geom_3857_simp_z0_4",
-            ),
-            get_health_boundary_view_sql(
-                "lhb_tiles_2022_z5_7",
-                "deprivation_scores_localhealthboard",
-                "lhb_code",
-                "lhb_name",
-                2022,
-                "wales",
-                "geom_3857_simp_z5_7",
-            ),
-            get_health_boundary_view_sql(
-                "lhb_tiles_2022_z8_10",
-                "deprivation_scores_localhealthboard",
-                "lhb_code",
-                "lhb_name",
-                2022,
-                "wales",
-                "geom_3857",
-            ),
-            get_health_boundary_view_sql(
-                "lhb_tiles_2022_z11_14",
-                "deprivation_scores_localhealthboard",
-                "lhb_code",
-                "lhb_name",
-                2022,
-                "wales",
-                "geom_3857",
-            ),
-            "CREATE VIEW public.nhser_tiles_2021 AS SELECT * FROM public.nhser_tiles_2021_z11_14;",
-            "CREATE VIEW public.icb_tiles_2023 AS SELECT * FROM public.icb_tiles_2023_z11_14;",
-            "CREATE VIEW public.lhb_tiles_2022 AS SELECT * FROM public.lhb_tiles_2022_z11_14;",
-            # Section 8: Final housekeeping
-            "GRANT SELECT ON ALL TABLES IN SCHEMA public TO PUBLIC;",
-            "ANALYZE deprivation_scores_lsoa;",
-            "ANALYZE deprivation_scores_datazone;",
-            "ANALYZE deprivation_scores_soa;",
-            "VACUUM ANALYZE public.uk_master_2011_z0_4;",
-            "VACUUM ANALYZE public.uk_master_2011_z5_7;",
-            "VACUUM ANALYZE public.uk_master_2011_z8_10;",
-            "VACUUM ANALYZE public.uk_master_2021_z0_4;",
-            "VACUUM ANALYZE public.uk_master_2021_z5_7;",
-            "VACUUM ANALYZE public.uk_master_2021_z8_10;",
-            "VACUUM ANALYZE public.uk_master_2011_z11_14;",
-            "VACUUM ANALYZE public.uk_master_2021_z11_14;",
-            "VACUUM ANALYZE public.lsoa_tiles_2011_z11_14;",
-            "VACUUM ANALYZE public.lsoa_tiles_2021_z11_14;",
-            "VACUUM ANALYZE public.la_tiles;",
-            "VACUUM ANALYZE public.nhser_tiles_2021_z0_4;",
-            "VACUUM ANALYZE public.nhser_tiles_2021_z5_7;",
-            "VACUUM ANALYZE public.nhser_tiles_2021_z8_10;",
-            "VACUUM ANALYZE public.nhser_tiles_2021_z11_14;",
-            "VACUUM ANALYZE public.icb_tiles_2023_z0_4;",
-            "VACUUM ANALYZE public.icb_tiles_2023_z5_7;",
-            "VACUUM ANALYZE public.icb_tiles_2023_z8_10;",
-            "VACUUM ANALYZE public.icb_tiles_2023_z11_14;",
-            "VACUUM ANALYZE public.lhb_tiles_2022_z0_4;",
-            "VACUUM ANALYZE public.lhb_tiles_2022_z5_7;",
-            "VACUUM ANALYZE public.lhb_tiles_2022_z8_10;",
-            "VACUUM ANALYZE public.lhb_tiles_2022_z11_14;",
-        ]
+                "DROP TABLE IF EXISTS public.lhb_tiles_2022_z0_4 CASCADE;",
+                "DROP TABLE IF EXISTS public.lhb_tiles_2022_z5_7 CASCADE;",
+                "DROP TABLE IF EXISTS public.lhb_tiles_2022_z8_10 CASCADE;",
+                "DROP TABLE IF EXISTS public.lhb_tiles_2022_z11_14 CASCADE;",
+            ]
+
+        # Section 3: Geoprocessing (WGS84 -> Web Mercator 3857)
+        if want("lsoas"):
+            sql_statements += [
+                "UPDATE deprivation_scores_lsoa SET geom_3857 = ST_MakeValid(geom_3857) WHERE NOT ST_IsValid(geom_3857);",
+                "UPDATE deprivation_scores_lsoa SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
+                "UPDATE deprivation_scores_datazone SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
+                "UPDATE deprivation_scores_soa SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
+            ]
+        if want("local-authorities"):
+            sql_statements += [
+                "UPDATE deprivation_scores_localauthority SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
+            ]
+        if want("nhs-regions"):
+            sql_statements += [
+                "UPDATE deprivation_scores_nhsenglishregion SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
+            ]
+        if want("integrated-care-boards"):
+            sql_statements += [
+                "UPDATE deprivation_scores_integratedcareboard SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
+            ]
+        if want("local-health-boards"):
+            sql_statements += [
+                "UPDATE deprivation_scores_localhealthboard SET geom_3857 = ST_Transform(geom, 3857) WHERE geom_3857 IS NULL AND geom IS NOT NULL;",
+            ]
+
+        # Section 4: Simplification
+        # Compute all simplification tiers in a single pass per table to reduce write overhead.
+        # z0-4: 1,500 m, z5-7: 200 m, z8-10: 60 m (all in EPSG:3857 metres).
+        if want("lsoas"):
+            sql_statements += [
+                "UPDATE deprivation_scores_lsoa SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+                "UPDATE deprivation_scores_datazone SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+                "UPDATE deprivation_scores_soa SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+            ]
+        if want("local-authorities"):
+            sql_statements += [
+                "UPDATE deprivation_scores_localauthority SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+            ]
+        if want("nhs-regions"):
+            sql_statements += [
+                "UPDATE deprivation_scores_nhsenglishregion SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+            ]
+        if want("integrated-care-boards"):
+            sql_statements += [
+                "UPDATE deprivation_scores_integratedcareboard SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+            ]
+        if want("local-health-boards"):
+            sql_statements += [
+                "UPDATE deprivation_scores_localhealthboard SET geom_3857_simp_z0_4 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 1500)), 3)), geom_3857_simp_z5_7 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 200)), 3)), geom_3857_simp_z8_10 = ST_Multi(ST_CollectionExtract(ST_MakeValid(ST_SimplifyPreserveTopology(geom_3857, 60)), 3)) WHERE geom_3857 IS NOT NULL;",
+            ]
+
+        # Section 5: Spatial indexing & clustering
+        if want("lsoas"):
+            sql_statements += [
+                # Raw geometry indexes (for z11+ and raw queries)
+                "CREATE INDEX IF NOT EXISTS idx_lsoa_3857 ON deprivation_scores_lsoa USING GIST (geom_3857);",
+                "CREATE INDEX IF NOT EXISTS idx_datazone_3857 ON deprivation_scores_datazone USING GIST (geom_3857);",
+                "CREATE INDEX IF NOT EXISTS idx_soa_3857 ON deprivation_scores_soa USING GIST (geom_3857);",
+                # Simplified geometry indexes (critical for tile performance)
+                "CREATE INDEX IF NOT EXISTS idx_lsoa_simp_z0_4 ON deprivation_scores_lsoa USING GIST (geom_3857_simp_z0_4);",
+                "CREATE INDEX IF NOT EXISTS idx_lsoa_simp_z5_7 ON deprivation_scores_lsoa USING GIST (geom_3857_simp_z5_7);",
+                "CREATE INDEX IF NOT EXISTS idx_lsoa_simp_z8_10 ON deprivation_scores_lsoa USING GIST (geom_3857_simp_z8_10);",
+                "CREATE INDEX IF NOT EXISTS idx_datazone_simp_z0_4 ON deprivation_scores_datazone USING GIST (geom_3857_simp_z0_4);",
+                "CREATE INDEX IF NOT EXISTS idx_datazone_simp_z5_7 ON deprivation_scores_datazone USING GIST (geom_3857_simp_z5_7);",
+                "CREATE INDEX IF NOT EXISTS idx_datazone_simp_z8_10 ON deprivation_scores_datazone USING GIST (geom_3857_simp_z8_10);",
+                "CREATE INDEX IF NOT EXISTS idx_soa_simp_z0_4 ON deprivation_scores_soa USING GIST (geom_3857_simp_z0_4);",
+                "CREATE INDEX IF NOT EXISTS idx_soa_simp_z5_7 ON deprivation_scores_soa USING GIST (geom_3857_simp_z5_7);",
+                "CREATE INDEX IF NOT EXISTS idx_soa_simp_z8_10 ON deprivation_scores_soa USING GIST (geom_3857_simp_z8_10);",
+                "CREATE INDEX IF NOT EXISTS idx_lsoa_year_id ON deprivation_scores_lsoa (year, id);",
+                "CREATE INDEX IF NOT EXISTS idx_english_imd_year_lsoa ON deprivation_scores_englishindexmultipledeprivation (year, lsoa_id);",
+                "CREATE INDEX IF NOT EXISTS idx_welsh_imd_year_lsoa ON deprivation_scores_welshindexmultipledeprivation (year, lsoa_id);",
+                "CLUSTER deprivation_scores_lsoa USING idx_lsoa_simp_z5_7;",
+                "CLUSTER deprivation_scores_datazone USING idx_datazone_simp_z5_7;",
+                "CLUSTER deprivation_scores_soa USING idx_soa_simp_z5_7;",
+            ]
+        if want("local-authorities"):
+            sql_statements += [
+                "CREATE INDEX IF NOT EXISTS idx_localauthority_3857 ON deprivation_scores_localauthority USING GIST (geom_3857);",
+                "CREATE INDEX IF NOT EXISTS idx_localauthority_simp_z0_4 ON deprivation_scores_localauthority USING GIST (geom_3857_simp_z0_4);",
+                "CREATE INDEX IF NOT EXISTS idx_localauthority_simp_z5_7 ON deprivation_scores_localauthority USING GIST (geom_3857_simp_z5_7);",
+                "CREATE INDEX IF NOT EXISTS idx_localauthority_simp_z8_10 ON deprivation_scores_localauthority USING GIST (geom_3857_simp_z8_10);",
+                "CLUSTER deprivation_scores_localauthority USING idx_localauthority_3857;",
+            ]
+        if want("nhs-regions"):
+            sql_statements += [
+                "CREATE INDEX IF NOT EXISTS idx_nhsenglishregion_3857 ON deprivation_scores_nhsenglishregion USING GIST (geom_3857);",
+                "CREATE INDEX IF NOT EXISTS idx_nhsenglishregion_simp_z0_4 ON deprivation_scores_nhsenglishregion USING GIST (geom_3857_simp_z0_4);",
+                "CREATE INDEX IF NOT EXISTS idx_nhsenglishregion_simp_z5_7 ON deprivation_scores_nhsenglishregion USING GIST (geom_3857_simp_z5_7);",
+                "CREATE INDEX IF NOT EXISTS idx_nhsenglishregion_simp_z8_10 ON deprivation_scores_nhsenglishregion USING GIST (geom_3857_simp_z8_10);",
+                "CLUSTER deprivation_scores_nhsenglishregion USING idx_nhsenglishregion_simp_z5_7;",
+            ]
+        if want("integrated-care-boards"):
+            sql_statements += [
+                "CREATE INDEX IF NOT EXISTS idx_integratedcareboard_3857 ON deprivation_scores_integratedcareboard USING GIST (geom_3857);",
+                "CREATE INDEX IF NOT EXISTS idx_integratedcareboard_simp_z0_4 ON deprivation_scores_integratedcareboard USING GIST (geom_3857_simp_z0_4);",
+                "CREATE INDEX IF NOT EXISTS idx_integratedcareboard_simp_z5_7 ON deprivation_scores_integratedcareboard USING GIST (geom_3857_simp_z5_7);",
+                "CREATE INDEX IF NOT EXISTS idx_integratedcareboard_simp_z8_10 ON deprivation_scores_integratedcareboard USING GIST (geom_3857_simp_z8_10);",
+                "CLUSTER deprivation_scores_integratedcareboard USING idx_integratedcareboard_simp_z5_7;",
+            ]
+        if want("local-health-boards"):
+            sql_statements += [
+                "CREATE INDEX IF NOT EXISTS idx_localhealthboard_3857 ON deprivation_scores_localhealthboard USING GIST (geom_3857);",
+                "CREATE INDEX IF NOT EXISTS idx_localhealthboard_simp_z0_4 ON deprivation_scores_localhealthboard USING GIST (geom_3857_simp_z0_4);",
+                "CREATE INDEX IF NOT EXISTS idx_localhealthboard_simp_z5_7 ON deprivation_scores_localhealthboard USING GIST (geom_3857_simp_z5_7);",
+                "CREATE INDEX IF NOT EXISTS idx_localhealthboard_simp_z8_10 ON deprivation_scores_localhealthboard USING GIST (geom_3857_simp_z8_10);",
+                "CLUSTER deprivation_scores_localhealthboard USING idx_localhealthboard_simp_z5_7;",
+            ]
+
+        # Section 6: LSOA tile tables
+        if want("lsoas"):
+            sql_statements += [
+                get_lsoa_view_sql("lsoa_tiles_2011_z0_4", "geom_3857_simp_z0_4", 2011),
+                get_lsoa_view_sql("lsoa_tiles_2011_z5_7", "geom_3857_simp_z5_7", 2011),
+                get_lsoa_view_sql(
+                    "lsoa_tiles_2011_z8_10", "geom_3857_simp_z8_10", 2011
+                ),
+                get_lsoa_view_sql("lsoa_tiles_2021_z0_4", "geom_3857_simp_z0_4", 2021),
+                get_lsoa_view_sql("lsoa_tiles_2021_z5_7", "geom_3857_simp_z5_7", 2021),
+                get_lsoa_view_sql(
+                    "lsoa_tiles_2021_z8_10", "geom_3857_simp_z8_10", 2021
+                ),
+                # z11-14: raw geometry — no simplification, prevents gap artifacts at high zoom
+                get_lsoa_view_sql("lsoa_tiles_2011_z11_14", "geom_3857", 2011),
+                get_lsoa_view_sql("lsoa_tiles_2021_z11_14", "geom_3857", 2021),
+            ]
+
+        # Section 7: UK Master + Overlay tile tables
+        if want("lsoas"):
+            sql_statements += [
+                get_uk_master_view_sql("uk_master_2011_z0_4", "simp_z0_4", 2011, 2019),
+                get_uk_master_view_sql("uk_master_2011_z5_7", "simp_z5_7", 2011, 2019),
+                get_uk_master_view_sql(
+                    "uk_master_2011_z8_10", "simp_z8_10", 2011, 2019
+                ),
+                get_uk_master_view_sql("uk_master_2021_z0_4", "simp_z0_4", 2021, 2025),
+                get_uk_master_view_sql("uk_master_2021_z5_7", "simp_z5_7", 2021, 2025),
+                get_uk_master_view_sql(
+                    "uk_master_2021_z8_10", "simp_z8_10", 2021, 2025
+                ),
+                # z11-14: raw geometry — no simplification, prevents gap artifacts at high zoom
+                get_uk_master_view_sql("uk_master_2011_z11_14", "3857", 2011, 2019),
+                get_uk_master_view_sql("uk_master_2021_z11_14", "3857", 2021, 2025),
+            ]
+        if want("local-authorities"):
+            sql_statements += [
+                get_la_tile_sql("la_tiles_z0_4", "geom_3857_simp_z0_4"),
+                get_la_tile_sql("la_tiles_z5_7", "geom_3857_simp_z5_7"),
+                get_la_tile_sql("la_tiles_z8_10", "geom_3857_simp_z8_10"),
+                # z11-14: reuse 60 m simplification — raw LA geometry can exceed pg_tileserv's
+                # vertex limit on complex coastal authorities even after tile clipping.
+                get_la_tile_sql("la_tiles_z11_14", "geom_3857_simp_z8_10"),
+                "CREATE VIEW public.la_tiles AS SELECT * FROM public.la_tiles_z11_14;",
+            ]
+        if want("nhs-regions"):
+            sql_statements += [
+                get_health_boundary_view_sql(
+                    "nhser_tiles_2021_z0_4",
+                    "deprivation_scores_nhsenglishregion",
+                    "nhser_code",
+                    "nhser_name",
+                    2021,
+                    "england",
+                    "geom_3857_simp_z0_4",
+                ),
+                get_health_boundary_view_sql(
+                    "nhser_tiles_2021_z5_7",
+                    "deprivation_scores_nhsenglishregion",
+                    "nhser_code",
+                    "nhser_name",
+                    2021,
+                    "england",
+                    "geom_3857_simp_z5_7",
+                ),
+                get_health_boundary_view_sql(
+                    "nhser_tiles_2021_z8_10",
+                    "deprivation_scores_nhsenglishregion",
+                    "nhser_code",
+                    "nhser_name",
+                    2021,
+                    "england",
+                    "geom_3857",
+                ),
+                get_health_boundary_view_sql(
+                    "nhser_tiles_2021_z11_14",
+                    "deprivation_scores_nhsenglishregion",
+                    "nhser_code",
+                    "nhser_name",
+                    2021,
+                    "england",
+                    "geom_3857",
+                ),
+                "CREATE VIEW public.nhser_tiles_2021 AS SELECT * FROM public.nhser_tiles_2021_z11_14;",
+            ]
+        if want("integrated-care-boards"):
+            sql_statements += [
+                get_health_boundary_view_sql(
+                    "icb_tiles_2023_z0_4",
+                    "deprivation_scores_integratedcareboard",
+                    "icb_code",
+                    "icb_name",
+                    2023,
+                    "england",
+                    "geom_3857_simp_z0_4",
+                ),
+                get_health_boundary_view_sql(
+                    "icb_tiles_2023_z5_7",
+                    "deprivation_scores_integratedcareboard",
+                    "icb_code",
+                    "icb_name",
+                    2023,
+                    "england",
+                    "geom_3857_simp_z5_7",
+                ),
+                get_health_boundary_view_sql(
+                    "icb_tiles_2023_z8_10",
+                    "deprivation_scores_integratedcareboard",
+                    "icb_code",
+                    "icb_name",
+                    2023,
+                    "england",
+                    "geom_3857",
+                ),
+                get_health_boundary_view_sql(
+                    "icb_tiles_2023_z11_14",
+                    "deprivation_scores_integratedcareboard",
+                    "icb_code",
+                    "icb_name",
+                    2023,
+                    "england",
+                    "geom_3857",
+                ),
+                "CREATE VIEW public.icb_tiles_2023 AS SELECT * FROM public.icb_tiles_2023_z11_14;",
+            ]
+        if want("local-health-boards"):
+            sql_statements += [
+                get_health_boundary_view_sql(
+                    "lhb_tiles_2022_z0_4",
+                    "deprivation_scores_localhealthboard",
+                    "lhb_code",
+                    "lhb_name",
+                    2022,
+                    "wales",
+                    "geom_3857_simp_z0_4",
+                ),
+                get_health_boundary_view_sql(
+                    "lhb_tiles_2022_z5_7",
+                    "deprivation_scores_localhealthboard",
+                    "lhb_code",
+                    "lhb_name",
+                    2022,
+                    "wales",
+                    "geom_3857_simp_z5_7",
+                ),
+                get_health_boundary_view_sql(
+                    "lhb_tiles_2022_z8_10",
+                    "deprivation_scores_localhealthboard",
+                    "lhb_code",
+                    "lhb_name",
+                    2022,
+                    "wales",
+                    "geom_3857",
+                ),
+                get_health_boundary_view_sql(
+                    "lhb_tiles_2022_z11_14",
+                    "deprivation_scores_localhealthboard",
+                    "lhb_code",
+                    "lhb_name",
+                    2022,
+                    "wales",
+                    "geom_3857",
+                ),
+                "CREATE VIEW public.lhb_tiles_2022 AS SELECT * FROM public.lhb_tiles_2022_z11_14;",
+            ]
+
+        # Section 8: Final housekeeping (GRANT always; ANALYZE/VACUUM per layer)
+        sql_statements += ["GRANT SELECT ON ALL TABLES IN SCHEMA public TO PUBLIC;"]
+        if want("lsoas"):
+            sql_statements += [
+                "ANALYZE deprivation_scores_lsoa;",
+                "ANALYZE deprivation_scores_datazone;",
+                "ANALYZE deprivation_scores_soa;",
+                "VACUUM ANALYZE public.uk_master_2011_z0_4;",
+                "VACUUM ANALYZE public.uk_master_2011_z5_7;",
+                "VACUUM ANALYZE public.uk_master_2011_z8_10;",
+                "VACUUM ANALYZE public.uk_master_2021_z0_4;",
+                "VACUUM ANALYZE public.uk_master_2021_z5_7;",
+                "VACUUM ANALYZE public.uk_master_2021_z8_10;",
+                "VACUUM ANALYZE public.uk_master_2011_z11_14;",
+                "VACUUM ANALYZE public.uk_master_2021_z11_14;",
+                "VACUUM ANALYZE public.lsoa_tiles_2011_z11_14;",
+                "VACUUM ANALYZE public.lsoa_tiles_2021_z11_14;",
+            ]
+        if want("local-authorities"):
+            sql_statements += [
+                "VACUUM ANALYZE public.la_tiles_z0_4;",
+                "VACUUM ANALYZE public.la_tiles_z5_7;",
+                "VACUUM ANALYZE public.la_tiles_z8_10;",
+                "VACUUM ANALYZE public.la_tiles_z11_14;",
+            ]
+        if want("nhs-regions"):
+            sql_statements += [
+                "VACUUM ANALYZE public.nhser_tiles_2021_z0_4;",
+                "VACUUM ANALYZE public.nhser_tiles_2021_z5_7;",
+                "VACUUM ANALYZE public.nhser_tiles_2021_z8_10;",
+                "VACUUM ANALYZE public.nhser_tiles_2021_z11_14;",
+            ]
+        if want("integrated-care-boards"):
+            sql_statements += [
+                "VACUUM ANALYZE public.icb_tiles_2023_z0_4;",
+                "VACUUM ANALYZE public.icb_tiles_2023_z5_7;",
+                "VACUUM ANALYZE public.icb_tiles_2023_z8_10;",
+                "VACUUM ANALYZE public.icb_tiles_2023_z11_14;",
+            ]
+        if want("local-health-boards"):
+            sql_statements += [
+                "VACUUM ANALYZE public.lhb_tiles_2022_z0_4;",
+                "VACUUM ANALYZE public.lhb_tiles_2022_z5_7;",
+                "VACUUM ANALYZE public.lhb_tiles_2022_z8_10;",
+                "VACUUM ANALYZE public.lhb_tiles_2022_z11_14;",
+            ]
 
         print("[POSTPROCESS] Starting SQL post-processing...")
         with connection.cursor() as cursor:
@@ -1244,6 +1420,25 @@ class Command(BaseCommand):
             action="store_true",
             help="Force re-import even if expected records with geom already exist",
         )
+        parser.add_argument(
+            "--layers",
+            nargs="+",
+            choices=[
+                "all",
+                "lsoas",
+                "local-authorities",
+                "nhs-regions",
+                "integrated-care-boards",
+                "local-health-boards",
+                "health-geographies",
+            ],
+            default=None,
+            help=(
+                "Limit process_geometries to specific overlay groups. "
+                "'health-geographies' expands to nhs-regions + integrated-care-boards + local-health-boards. "
+                "Omit to process all layers (equivalent to 'all')."
+            ),
+        )
 
     def handle(self, *args, **options):
         force = options.get("force", False)
@@ -1419,6 +1614,7 @@ class Command(BaseCommand):
             self.test_geometries()
             return
         if options.get("mode") == "process_geometries":
+            layers = options.get("layers")
             self.stdout.write(
                 "\n"
                 + self.style.SUCCESS(
@@ -1426,7 +1622,7 @@ class Command(BaseCommand):
                 )
                 + "\n"
             )
-            self._run_post_processing_sql()
+            self._run_post_processing_sql(layers=layers)
             self.test_geometries()
             return
 

--- a/deprivation_scores/management/commands/seed.py
+++ b/deprivation_scores/management/commands/seed.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 import geopandas as gpd
 import pandas as pd
 from sqlalchemy import create_engine
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
 from django.conf import settings
 from ...models import (
@@ -1385,7 +1385,48 @@ class Command(BaseCommand):
                     f"  {status} {label}: 2011({count_11}) | 2021({count_21}) polygons."
                 )
 
-            # 3. Coordinate System Verification
+            # 4. Boundary tile tier verification
+            self.stdout.write("Checking boundary tier tables (z0_4, z5_7, z8_10, z11_14)...")
+            tiered_boundaries = {
+                "Local Authorities": "la_tiles",
+                "NHS Regions": "nhser_tiles_2021",
+                "Integrated Care Boards": "icb_tiles_2023",
+                "Local Health Boards": "lhb_tiles_2022",
+            }
+            tiers = ["z0_4", "z5_7", "z8_10", "z11_14"]
+            boundary_failures = []
+
+            for label, prefix in tiered_boundaries.items():
+                for tier in tiers:
+                    table_name = f"{prefix}_{tier}"
+                    if not table_or_view_exists(cursor, table_name):
+                        boundary_failures.append(
+                            f"Missing required boundary table: public.{table_name}"
+                        )
+                        continue
+
+                    cursor.execute(f"SELECT COUNT(*) FROM public.{table_name};")
+                    row = cursor.fetchone()
+                    row_count = row[0] if row else 0
+                    if row_count <= 0:
+                        boundary_failures.append(
+                            f"Boundary table is empty: public.{table_name}"
+                        )
+                        status = "❌"
+                    else:
+                        status = "✅"
+
+                    self.stdout.write(
+                        f"  {status} {label} {tier}: {row_count} rows"
+                    )
+
+            if boundary_failures:
+                failures = "\n  - " + "\n  - ".join(boundary_failures)
+                raise CommandError(
+                    "Boundary tier validation failed:" + failures
+                )
+
+            # 5. Coordinate System Verification
             if table_or_view_exists(cursor, "uk_master_2021_z8_10"):
                 cursor.execute(
                     "SELECT ST_X(ST_Centroid(geom)) FROM public.uk_master_2021_z8_10 LIMIT 1;"

--- a/site/docs/boundaries.md
+++ b/site/docs/boundaries.md
@@ -213,6 +213,11 @@ After the base IMD data has been seeded, run the geometry enrichment:
 python manage.py seed --mode import_bfc_boundaries
 ```
 
+Validation semantics:
+
+* `import_bfc_boundaries` runs post-processing and then `test_geometries` in strict mode.
+* Strict mode fails the command if required boundary tier tables are missing or empty.
+
 To update or overwrite existing geometries, use the `--force` flag.
 
 If you only changed exposed tile properties (for example adding `area_name`), you can rebuild just the post-processed tile tables without re-downloading boundaries:
@@ -220,6 +225,18 @@ If you only changed exposed tile properties (for example adding `area_name`), yo
 ```bash
 python manage.py seed --mode process_geometries
 ```
+
+For scoped rebuilds, use `--layers`:
+
+```bash
+python manage.py seed --mode process_geometries --layers local-authorities
+python manage.py seed --mode process_geometries --layers health-geographies
+```
+
+Validation semantics for `process_geometries`:
+
+* Full rebuild (`process_geometries` with no `--layers`, or `--layers all`) runs `test_geometries` in strict mode.
+* Scoped rebuild (`process_geometries --layers <subset>`) runs `test_geometries` in report-only mode for boundary-tier completeness, so missing/empty unrelated tiers are logged but do not abort the command.
 
 ## References
 

--- a/site/docs/managed-database-seeding.md
+++ b/site/docs/managed-database-seeding.md
@@ -55,6 +55,7 @@ Azure Container App
 ```
 
 The managed database persists independently of application deployments and only needs seeding when:
+
 - Initially setting up a new environment
 - Updating to a new data release version
 - Restoring from a known-good state
@@ -107,6 +108,7 @@ az containerapp exec \
 ```
 
 **Parameter Explanation**:
+
 - `--name`: Your Azure Container App name
 - `--resource-group`: Your Azure resource group
 - `--container`: Container to execute in (usually `web`)
@@ -164,6 +166,7 @@ ERROR: extension "postgis_tiger_geocoder" does not exist
 ```
 
 These extensions are:
+
 - Not available in Azure PostgreSQL's allowlist
 - Not required for UK census data (they're for US address geocoding)
 - Safely excluded from the restore process

--- a/site/index.html
+++ b/site/index.html
@@ -188,8 +188,8 @@ Update process for @rcpch/imd-map CDN pin:
 Then update both the @<version> in src and the integrity value below.
 -->
 <script
-    src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.1.2/dist/umd/rcpch-imd-map.min.js"
-    integrity="sha384-SOHGpklzaQ2QQRsOvUcliOu8PNNPAqt5H7GMjmNAV0VTsuJQO1ploVvDZ8N/4AmC"
+    src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.2.0/dist/umd/rcpch-imd-map.min.js"
+    integrity="sha384-dab5Ld+1N1MM7BV+0DEIab9GFQ8wdXRV0gyGqIqw9XjGi9f4ddcaTXSADB2jmSC8"
     crossorigin="anonymous"></script>
 <script src="map-logic.js"></script>
 

--- a/site/index.html
+++ b/site/index.html
@@ -158,14 +158,14 @@
 
         <div style="margin-top:8px; padding-top:8px; border-top:1px solid #e5e7eb;">
             <label style="display:flex;align-items:center;gap:8px;font-size:0.82rem;color:#333;cursor:pointer;" id="nhser-toggle-group">
-                <input id="nhser-toggle" type="checkbox" style="accent-color:#1e40af;">
-                Show NHS England Regions
+                <input id="nhser-toggle" type="checkbox" style="accent-color:#0f766e;">
+                Show NHS England regions
             </label>
             <div id="nhser-note" style="font-size:0.7rem;color:#888;margin-top:4px;min-height:1em;padding-left:24px;"></div>
 
             <label style="display:flex;align-items:center;gap:8px;font-size:0.82rem;color:#333;cursor:pointer; margin-top:6px;" id="icb-toggle-group">
-                <input id="icb-toggle" type="checkbox" style="accent-color:#9333ea;">
-                Show Integrated Care Boards
+                <input id="icb-toggle" type="checkbox" style="accent-color:#b45309;">
+                Show ICBs
             </label>
             <div id="icb-note" style="font-size:0.7rem;color:#888;margin-top:4px;min-height:1em;padding-left:24px;"></div>
 
@@ -188,8 +188,8 @@ Update process for @rcpch/imd-map CDN pin:
 Then update both the @<version> in src and the integrity value below.
 -->
 <script
-    src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.2.0/dist/umd/rcpch-imd-map.min.js"
-    integrity="sha384-dab5Ld+1N1MM7BV+0DEIab9GFQ8wdXRV0gyGqIqw9XjGi9f4ddcaTXSADB2jmSC8"
+    src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.2.1/dist/umd/rcpch-imd-map.min.js"
+    integrity="sha384-mb3+8/uvp+E9qbtZ2EWShqg8oyKtKuY0vdBMr8NOC3AhzMRGLpM23jshmkmZwugU"
     crossorigin="anonymous"></script>
 <script src="map-logic.js"></script>
 

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -310,21 +310,22 @@ function initMap() {
     style: {
       choropleth: {
         baseColorByNation: {
-          england: "#67000d",
+          england: "#b91c1c",
           scotland: "#08306b",
           wales: "#00441b",
           northern_ireland: "#7f2704",
         },
+        fillOpacity: 0.62,
       },
       boundaries: {
         localAuthorityColor: "#374151",
-        localAuthorityWidth: 1,
-        nhserColor: "#1e40af",
-        nhserWidth: 1.5,
-        icbColor: "#9333ea",
-        icbWidth: 1.25,
+        localAuthorityWidth: 1.5,
+        nhserColor: "#0f766e",
+        nhserWidth: 2.4,
+        icbColor: "#b45309",
+        icbWidth: 2.2,
         lhbColor: "#166534",
-        lhbWidth: 1.4,
+        lhbWidth: 2.2,
       },
       tooltip: {
         backgroundColor: "#0d0d58",


### PR DESCRIPTION
## Summary

This branch fixes the local authority overlay path that was still serving overly detailed geometry at all zoom levels and adds a faster way to rebuild only the geometry layers being iterated on.

It does three things:

- adds zoom-tiered `la_tiles` materialization in post-processing so local authority tiles can be served from banded tables instead of a single heavy layer
- adds `--layers` support to `python manage.py seed --mode process_geometries` so expensive rebuilds can be limited to specific overlay groups
- updates the site CDN pin to `@rcpch/imd-map@0.2.0` and refreshes the SRI hash so the demo site consumes the overlay zoom-switching logic from the mapping library

## Backend changes

- adds local-authority simplification columns and tiered materialized tile tables for:
  - `public.la_tiles_z0_4`
  - `public.la_tiles_z5_7`
  - `public.la_tiles_z8_10`
  - `public.la_tiles_z11_14`
- keeps the compatibility object `public.la_tiles`, now backed by the high-zoom tier view
- adds selective layer processing for `process_geometries`, including:
  - `local-authorities`
  - `nhs-regions`
  - `integrated-care-boards`
  - `local-health-boards`
  - `health-geographies`
  - `lsoas`
- leaves the existing LSOA / SOA / DataZone / IMD logic intact; the functional change is the new local-authority tiering and execution scoping

## Docs and site

- updates `AGENTS.md` with `--layers` usage and examples
- updates `site/index.html` to load `@rcpch/imd-map@0.2.0`
- refreshes the CDN integrity value using the published 0.2.0 UMD bundle

## Validation

- ran `python3 -m py_compile deprivation_scores/management/commands/seed.py`
- recomputed the SHA-384 SRI directly from jsDelivr for `@rcpch/imd-map@0.2.0`
- checked the updated site HTML reference and confirmed no editor errors in `site/index.html`

## Notes

- this branch assumes the mapping component now targets the zoom-tiered overlay endpoints for local authorities and health boundaries
- full `process_geometries` / tile rebuild was not run as part of this change
