### PR TITLE
Fix health z8_10 simplification and automate JS cache-busting

### DIFF
--- a/.github/workflows/deploy_containerapps.yml
+++ b/.github/workflows/deploy_containerapps.yml
@@ -43,6 +43,27 @@ jobs:
       - name: Burn in build info
         run: s/get-build-info > build_info.json
 
+      - name: Inject static asset version
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          build_info_path = Path('build_info.json')
+          index_path = Path('site/index.html')
+
+          build_info = json.loads(build_info_path.read_text(encoding='utf-8'))
+          sha = str(build_info.get('latest_git_commit', '')).strip()
+          asset_version = (sha[:12] if sha else 'dev')
+
+          html = index_path.read_text(encoding='utf-8')
+          html = html.replace('__ASSET_VERSION__', asset_version)
+          index_path.write_text(html, encoding='utf-8')
+
+          print(f'Injected asset version: {asset_version}')
+          PY
+
       - name: Build and push web image
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,15 @@ Misc:
 - `s/get-build-info`
   - Outputs current git hash and branch JSON.
 
+### Frontend Cache-Busting (Automated on Deploy)
+
+- `site/index.html` includes deploy-time placeholders in map script tags:
+  - `config.js?v=__ASSET_VERSION__`
+  - `map-logic.js?v=__ASSET_VERSION__`
+- The deploy workflow (`.github/workflows/deploy_containerapps.yml`) replaces `__ASSET_VERSION__` with the first 12 chars of `latest_git_commit` from `build_info.json`.
+- This ensures each deployed revision serves a unique JS URL and avoids stale browser/CDN asset caches after map/frontend updates.
+- In local development (without deploy replacement), the placeholder string remains literal and is still a valid query string.
+
 ## Publishing and deployment docs
 
 For full operator guidance, use these docs in `site/docs/`:

--- a/deprivation_scores/management/commands/seed.py
+++ b/deprivation_scores/management/commands/seed.py
@@ -744,7 +744,7 @@ class Command(BaseCommand):
                     "nhser_name",
                     2021,
                     "england",
-                    "geom_3857",
+                    "geom_3857_simp_z8_10",
                 ),
                 get_health_boundary_view_sql(
                     "nhser_tiles_2021_z11_14",
@@ -784,7 +784,7 @@ class Command(BaseCommand):
                     "icb_name",
                     2023,
                     "england",
-                    "geom_3857",
+                    "geom_3857_simp_z8_10",
                 ),
                 get_health_boundary_view_sql(
                     "icb_tiles_2023_z11_14",
@@ -824,7 +824,7 @@ class Command(BaseCommand):
                     "lhb_name",
                     2022,
                     "wales",
-                    "geom_3857",
+                    "geom_3857_simp_z8_10",
                 ),
                 get_health_boundary_view_sql(
                     "lhb_tiles_2022_z11_14",

--- a/site/docs/boundaries.md
+++ b/site/docs/boundaries.md
@@ -99,6 +99,15 @@ To achieve fast rendering on the frontend:
     * `<era>` is either `2011` (IMD 2019 England / 2019 Wales) or `2021` (IMD 2025 England / 2019 Wales).
 3. **CDN**: Tiles are cached at the edge via a CDN to ensure sub-second map interactivity.
 
+### Frontend script cache-busting
+
+To reduce stale frontend behavior after map-layer changes, `site/index.html` uses versioned local script URLs:
+
+* `config.js?v=__ASSET_VERSION__`
+* `map-logic.js?v=__ASSET_VERSION__`
+
+During deployment, `.github/workflows/deploy_containerapps.yml` injects `__ASSET_VERSION__` from the current git commit hash (first 12 chars via `build_info.json`). This gives each release unique JS asset URLs, so browser/CDN caches naturally refresh on deploy.
+
 ## Current Dataset Mapping (Map Behaviour)
 
 This section summarizes what the map currently renders by view. Use this as the quick reference for boundary year, IMD year, and local authority metadata in tile properties.

--- a/site/index.html
+++ b/site/index.html
@@ -180,7 +180,7 @@
 
 <div id="map"></div>
 
-<script src="config.js"></script>
+<script src="config.js?v=__ASSET_VERSION__"></script>
 <!--
 Update process for @rcpch/imd-map CDN pin:
 1) npm view @rcpch/imd-map version
@@ -191,7 +191,7 @@ Then update both the @<version> in src and the integrity value below.
     src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.2.1/dist/umd/rcpch-imd-map.min.js"
     integrity="sha384-mb3+8/uvp+E9qbtZ2EWShqg8oyKtKuY0vdBMr8NOC3AhzMRGLpM23jshmkmZwugU"
     crossorigin="anonymous"></script>
-<script src="map-logic.js"></script>
+<script src="map-logic.js?v=__ASSET_VERSION__"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary\n- fix health boundary z8_10 layers to use geom_3857_simp_z8_10\n- automate frontend script cache-busting on deploy using commit-derived asset version\n- update docs in AGENTS.md and site/docs/boundaries.md\n\n## Notes\n- version token injection happens in deploy workflow from build_info.json\n- map page scripts now use __ASSET_VERSION__ placeholders replaced at deploy time