### PR TITLE
Clarify mixed-vintage eras and fix Welsh deciles in 2021 tiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,11 +74,16 @@ To avoid doc drift, treat `site/docs/boundaries.md` as the canonical source for:
 
 Current map behaviour summary (quick reference only):
 
-| View | England | Wales | Scotland | N. Ireland |
+| View / Era | England | Wales | Scotland | N. Ireland |
 | --- | --- | --- | --- | --- |
-| All UK | 2011 LSOA + 2019 IMD | 2011 LSOA + 2019 WIMD | 2011 DataZone + 2020 SIMD | 2001 SOA + 2017 NIMDM |
-| England-only (era toggle = 2021) | 2021 LSOA + 2025 IMD | n/a | n/a | n/a |
-| England-only (era toggle = 2011) | 2011 LSOA + 2019 IMD | n/a | n/a | n/a |
+| All UK (era = 2021) | 2021 LSOA + 2025 IMD | 2011 LSOA + 2019 WIMD | 2011 DataZone + 2020 SIMD | 2001 SOA + 2017 NIMDM |
+| All UK (era = 2011) | 2011 LSOA + 2019 IMD | 2011 LSOA + 2019 WIMD | 2011 DataZone + 2020 SIMD | 2001 SOA + 2017 NIMDM |
+| England-only (era = 2021) | 2021 LSOA + 2025 IMD | n/a | n/a | n/a |
+| England-only (era = 2011) | 2011 LSOA + 2019 IMD | n/a | n/a | n/a |
+
+Key point: the `uk_master_2021_*` tables are **mixed vintage** — England uses 2021 LSOAs and 2025 IMD, while Wales, Scotland and N. Ireland remain on their respective 2011-era boundaries and latest available IMD data. Wales has not adopted 2021 LSOA boundaries and has not published an IMD since WIMD 2019; Scotland and N. Ireland are similarly frozen on older vintages. There is no purely "all-2021" UK-wide dataset.
+
+This means the era toggle has a meaningful effect on the All UK view (switching between 2019 and 2025 IMD data for England), not just on England-only views. Consuming applications (e.g. NPDA) can use `era=2021` for current-cohort maps and `era=2011` for historical-cohort maps, with Wales and other nations appearing identically in both because no newer data exists for them.
 
 Local authority boundary import summary:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,12 @@ Key point: the `uk_master_2021_*` tables are **mixed vintage** — England uses 
 
 This means the era toggle has a meaningful effect on the All UK view (switching between 2019 and 2025 IMD data for England), not just on England-only views. Consuming applications (e.g. NPDA) can use `era=2021` for current-cohort maps and `era=2011` for historical-cohort maps, with Wales and other nations appearing identically in both because no newer data exists for them.
 
+Frontend control behavior (`site/index.html` + `site/map-logic.js`) is currently:
+
+- Default view: `nation=all`, `era=2021`.
+- Era selector is enabled for `all` and `england`, and disabled for `wales`, `scotland`, and `northern_ireland`.
+- In `all` view, switching era swaps between `uk_master_2021_*` and `uk_master_2011_*`; this only changes England's boundary/IMD pairing while the other nations remain on their latest available published datasets.
+
 Local authority boundary import summary:
 
 - England/Wales LA geometry is imported from the 2019 and 2024 ONS LAD BFC services.
@@ -184,6 +190,7 @@ Added April 2026. Three new health administrative boundaries imported via BFC (B
 | Local Health Boards | 2022 | Wales | LHB22CD | `lhb_code` | 7 |
 
 All map to 2021 LSOA boundaries. Imported as part of `import_bfc_boundaries` mode. Models include:
+
 - `NHSEnglishRegion`, `IntegratedCareBoard`, `LocalHealthBoard` in `deprivation_scores/models.py`
 - Unique constraint on `(code, year)` to support multi-year versioning
 - Full geometry processing (3857 transform, simplification, spatial indexes)

--- a/deprivation_scores/management/commands/seed.py
+++ b/deprivation_scores/management/commands/seed.py
@@ -182,6 +182,7 @@ class Command(BaseCommand):
             )
 
             # Fixed boundary years for Scotland and NI
+            wales_boundary_year = 2011
             scotland_boundary_year = 2011
             ni_boundary_year = 2001
 
@@ -274,7 +275,7 @@ class Command(BaseCommand):
             ) lhb ON TRUE
             WHERE l.lsoa_code LIKE 'W%' 
                 AND l.{actual_geom_col} IS NOT NULL 
-                AND l.year = {boundary_year}
+                AND l.year = {wales_boundary_year}
 
             UNION ALL
 

--- a/s/release-dump
+++ b/s/release-dump
@@ -11,6 +11,8 @@ echo "=========================================="
 : "${GITHUB_REPO:=rcpch/rcpch-census-platform}"
 
 # ---- Config ----
+: "${CHANGELOG_FILE:=}"
+: "${GENERATE_RELEASE_NOTES:=false}"
 MAX_SIZE_MB=1900
 BASENAME="rcpch-census-${RELEASE_VERSION}.dump"
 WORK_DIR="$(mktemp -d)"
@@ -18,8 +20,18 @@ WORK_DIR="$(mktemp -d)"
 echo "Dump file: $DUMP_FILE"
 echo "Release:   $RELEASE_VERSION"
 
+if [ -n "$CHANGELOG_FILE" ] && [ ! -f "$CHANGELOG_FILE" ]; then
+  echo "Changelog file not found: $CHANGELOG_FILE" >&2
+  exit 1
+fi
+
 cp "$DUMP_FILE" "$WORK_DIR/$BASENAME"
 cd "$WORK_DIR"
+
+RELEASE_NOTES="Automated database dump"
+if [ -n "$CHANGELOG_FILE" ]; then
+  RELEASE_NOTES="$(cat "$CHANGELOG_FILE")"
+fi
 
 # ---- Split if necessary ----
 SIZE_MB=$(du -m "$BASENAME" | cut -f1)
@@ -35,10 +47,21 @@ fi
 
 # ---- Create or update release ----
 if ! gh release view "$RELEASE_VERSION" -R "$GITHUB_REPO" >/dev/null 2>&1; then
+  CREATE_ARGS=(
+    -R "$GITHUB_REPO"
+    --title "Database dump ${RELEASE_VERSION}"
+  )
+
+  if [ "$GENERATE_RELEASE_NOTES" = "true" ]; then
+    CREATE_ARGS+=(--generate-notes)
+  fi
+
+  if [ -n "$RELEASE_NOTES" ]; then
+    CREATE_ARGS+=(--notes "$RELEASE_NOTES")
+  fi
+
   gh release create "$RELEASE_VERSION" \
-    -R "$GITHUB_REPO" \
-    --title "Database dump ${RELEASE_VERSION}" \
-    --notes "Automated database dump"
+    "${CREATE_ARGS[@]}"
 fi
 
 # ---- Upload assets ----

--- a/site/docs/boundaries.md
+++ b/site/docs/boundaries.md
@@ -96,7 +96,7 @@ To achieve fast rendering on the frontend:
     * `z0-z4`: Uses `public.uk_master_<era>_z0_4` (high simplification).
     * `z5-z7`: Uses `public.uk_master_<era>_z5_7` (medium simplification).
     * `z8+`: Uses `public.uk_master_<era>_z8_10` (full detail BFC).
-    * `<era>` is either `2011` (IMD 2019 England / 2019 Wales) or `2021` (IMD 2025 England / 2019 Wales).
+    * `<era>` is either `2011` or `2021`. Both eras are valid for All UK and England-only views. The `uk_master_2021_*` tables are mixed vintage: England uses 2021 LSOAs + 2025 IMD while Wales, Scotland and N. Ireland remain on their 2011-era boundaries and latest available IMD (see table below).
 3. **CDN**: Tiles are cached at the edge via a CDN to ensure sub-second map interactivity.
 
 ### Frontend script cache-busting
@@ -114,17 +114,32 @@ This section summarizes what the map currently renders by view. Use this as the 
 
 | View | Nation | Boundary Type/Year (`year`) | IMD Dataset/Year (`imd_year`) | LA/LAD metadata year (`la_year`) | Match note |
 | :--- | :--- | :--- | :--- | :--- | :--- |
+| All UK (`uk_master_2021_*`) | England | LSOA 2021 | IMD 2025 | 2024 | Lookup-linked (2021 LSOAs reference 2024 LADs in source lookup file) |
+| All UK (`uk_master_2021_*`) | Wales | LSOA 2011 | WIMD 2019 | 2019 | No 2021 LSOA boundaries or post-2019 WIMD published for Wales |
+| All UK (`uk_master_2021_*`) | Scotland | DataZone 2011 | SIMD 2020 | 2011 | No post-2011 DataZone boundaries or post-2020 SIMD published for Scotland |
+| All UK (`uk_master_2021_*`) | Northern Ireland | SOA 2001 | NIMDM 2017 | `NULL` | Not applicable in current layer (`la_*` fields are `NULL`) |
 | All UK (`uk_master_2011_*`) | England | LSOA 2011 | IMD 2019 | 2019 | Lookup-linked (2011 LSOAs reference 2019 LADs in source lookup file) |
 | All UK (`uk_master_2011_*`) | Wales | LSOA 2011 | WIMD 2019 | 2019 | Lookup-linked (2011 LSOAs reference 2019 LADs in source lookup file) |
 | All UK (`uk_master_2011_*`) | Scotland | DataZone 2011 | SIMD 2020 | 2011 | Lookup-linked (2011 DataZones reference 2011 LAs) |
 | All UK (`uk_master_2011_*`) | Northern Ireland | SOA 2001 | NIMDM 2017 | `NULL` | Not applicable in current layer (`la_*` fields are `NULL`) |
-| England-only (era = 2011) | England | LSOA 2011 | IMD 2019 | 2019 | Lookup-linked (2011 LSOAs reference 2019 LADs in source lookup file) |
 | England-only (era = 2021) | England | LSOA 2021 | IMD 2025 | 2024 | Lookup-linked (2021 LSOAs reference 2024 LADs in source lookup file) |
+| England-only (era = 2011) | England | LSOA 2011 | IMD 2019 | 2019 | Lookup-linked (2011 LSOAs reference 2019 LADs in source lookup file) |
 
 For the standalone `public.la_tiles` overlay source, the year mapping is currently:
 
 * England/Wales: `2019` and `2024`
 * Scotland: `2011`
+
+### Mixed-vintage note for `uk_master_2021_*`
+
+The `uk_master_2021_*` tables contain data from different boundary vintages depending on nation. England uses 2021 LSOAs and 2025 IMD data; Wales, Scotland and N. Ireland remain on their 2011-era boundaries and their most recent available IMD datasets. This reflects the actual availability of published data — Wales has not adopted 2021 LSOA boundaries and has not published a WIMD since 2019; Scotland and N. Ireland are similarly frozen on older vintages. There is no purely "all-2021" UK-wide dataset.
+
+Consuming applications can therefore:
+
+- Pass `era=2021` to show the latest available data for each nation (England on 2021 LSOAs + 2025 IMD; Wales on 2011 LSOAs + 2019 WIMD).
+- Pass `era=2011` to show a consistent historical-cohort view where England also uses 2011 LSOAs + 2019 IMD, matching Wales and other nations.
+
+The era toggle is meaningful for All UK views, not only England-only views.
 
 ### Important alignment caveat
 

--- a/site/docs/boundaries.md
+++ b/site/docs/boundaries.md
@@ -136,10 +136,18 @@ The `uk_master_2021_*` tables contain data from different boundary vintages depe
 
 Consuming applications can therefore:
 
-- Pass `era=2021` to show the latest available data for each nation (England on 2021 LSOAs + 2025 IMD; Wales on 2011 LSOAs + 2019 WIMD).
-- Pass `era=2011` to show a consistent historical-cohort view where England also uses 2011 LSOAs + 2019 IMD, matching Wales and other nations.
+* Pass `era=2021` to show the latest available data for each nation (England on 2021 LSOAs + 2025 IMD; Wales on 2011 LSOAs + 2019 WIMD).
+* Pass `era=2011` to show a consistent historical-cohort view where England also uses 2011 LSOAs + 2019 IMD, matching Wales and other nations.
 
 The era toggle is meaningful for All UK views, not only England-only views.
+
+### Frontend behavior (site map)
+
+Current `site/` map control behavior is:
+
+* Default load uses `initialNation: 'all'` and `initialEra: '2021'`.
+* The era selector is enabled for `all` and `england`, and disabled for `wales`, `scotland`, and `northern_ireland`.
+* In `all` view, changing era switches tile family between `uk_master_2021_*` and `uk_master_2011_*`; this changes England's IMD/boundary pairing while the other nations remain on their latest available published datasets.
 
 ### Important alignment caveat
 

--- a/site/index.html
+++ b/site/index.html
@@ -127,7 +127,7 @@
     <h2 style="margin-top:0; font-size: 1.2rem; color: #0d0d58; margin-bottom: 20px;">Map Controls</h2>
     
     <div class="control-group" id="era-toggle-group">
-        <label class="control-label" for="era-toggle">England IMD Year</label>
+        <label class="control-label" for="era-toggle">Era (England IMD/LSOA)</label>
         <select id="era-toggle" class="select select-bordered w-full select-sm">
             <option value="2021" selected>2025 IMD &middot; 2021 LSOAs</option>
             <option value="2011">2019 IMD &middot; 2011 LSOAs</option>
@@ -188,8 +188,8 @@ Update process for @rcpch/imd-map CDN pin:
 Then update both the @<version> in src and the integrity value below.
 -->
 <script
-    src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.2.1/dist/umd/rcpch-imd-map.min.js"
-    integrity="sha384-mb3+8/uvp+E9qbtZ2EWShqg8oyKtKuY0vdBMr8NOC3AhzMRGLpM23jshmkmZwugU"
+    src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.0/dist/umd/rcpch-imd-map.min.js"
+    integrity="sha384-LDZdwn7z+54qTPkti5mXktF6aIIW5wLL5xu+/j0SkMtngO+lLZzx3o2r5jUjMURT"
     crossorigin="anonymous"></script>
 <script src="map-logic.js?v=__ASSET_VERSION__"></script>
 

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -93,14 +93,14 @@ function updateDatasetInfo(selectedNation, era) {
     northern_ireland: "N. Ireland",
   };
 
-  const eraActive = selectedNation === "england";
+  const eraActive = selectedNation === "england" || selectedNation === "all";
   eraGroup.style.opacity = eraActive ? "1" : "0.45";
   eraSelect.disabled = !eraActive;
   noteEl.textContent = eraActive
-    ? ""
-    : selectedNation === "all"
-      ? "All UK view uses 2011-era boundaries for all nations"
-      : "Era selector applies to England only";
+    ? selectedNation === "all"
+      ? "All UK: era switch changes England between 2025/2021 and 2019/2011 datasets"
+      : ""
+    : "Era selector applies to England and All UK";
 
   const nations =
     selectedNation === "all"
@@ -108,8 +108,7 @@ function updateDatasetInfo(selectedNation, era) {
       : [selectedNation];
 
   const lines = nations.map((n) => {
-    const eraKey =
-      selectedNation === "all" ? "2011" : n === "england" ? era : "2011";
+    const eraKey = n === "england" ? era : "2011";
     const d = DATASET_INFO[n][eraKey];
     const noteStr = d.note
       ? ` <span style="color:#9a6700;font-style:italic;">(${d.note})</span>`
@@ -137,7 +136,9 @@ function updateLocalAuthorityControlState() {
     ? currentNation === "england" && currentEra === "2021"
       ? "Using 2024 Local Authority boundaries"
       : currentNation === "all"
-        ? "All UK: England/Wales 2019 + Scotland 2011 boundaries"
+        ? currentEra === "2021"
+          ? "All UK: England 2024 + Wales 2019 + Scotland 2011 boundaries"
+          : "All UK: England/Wales 2019 + Scotland 2011 boundaries"
         : "Showing matching Local Authority boundaries for this view"
     : "Not available for Northern Ireland in this layer";
 }


### PR DESCRIPTION
## Summary
This PR aligns era behavior docs and frontend controls with the mixed-vintage UK tile model, updates the map component to `@rcpch/imd-map@0.3.0`, and fixes Welsh decile materialization for `uk_master_2021_*` tiles.

## Changes
- docs: clarify mixed-vintage UK era structure in AGENTS and boundaries docs
- site: pin `@rcpch/imd-map@0.3.0` CDN + SRI and enable era selector for `all` and `england`
- site: update era note/copy and all-UK era behavior messaging
- fix(sql): in `get_uk_master_view_sql()`, force Wales boundary year to 2011 for `uk_master_2021_*` materialization so WIMD joins resolve correctly

## Why
Wales was inheriting `boundary_year=2021` in the UK master 2021 materialization path, selecting Welsh 2021 LSOA rows that do not join to WIMD 2019 records, producing `imd_decile=0` across Wales.

## Validation
- Tile tables rebuilt and present
- Source and tile geometries confirmed non-null
- Welsh source-join validation:
  - `l.year=2011` -> deciles populated (1..10)
  - `l.year=2021` -> deciles all 0 (demonstrates prior failure mode)