### PR TITLE
Inject GitHub Pages API key for APIM tile access

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,10 @@ jobs:
         run: |
           echo "window.PUBLIC_TILES_URL = '${{ secrets.PUBLIC_TILES_URL }}';" > site/config.js
 
+      - name: Inject CENSUS_API_KEY config
+        run: |
+          echo "window.CENSUS_API_KEY = '${{ secrets.RCPCH_CENSUS_PLATFORM_GITHUB_PAGES_API_KEY }}';" >> site/config.js
+
       - name: Configure Pages
         uses: actions/configure-pages@v5
 

--- a/site/config.js
+++ b/site/config.js
@@ -5,3 +5,7 @@
 
 // Example override:
 // window.PUBLIC_TILES_URL = "https://api.rcpch.ac.uk/deprivation/v2/tiles";
+
+// API Key for APIM (injected at build time in GitHub Pages deployment)
+// Leave undefined to run locally without authentication
+// window.CENSUS_API_KEY = "your-api-key-here";

--- a/site/imd-lookup.html
+++ b/site/imd-lookup.html
@@ -173,6 +173,15 @@
     const loadingDiv = document.getElementById('loading');
     const apiAuthNotice = document.getElementById('api-auth-notice');
 
+    function isLocalRuntime() {
+      return (
+        window.location.protocol === 'file:' ||
+        window.location.hostname === '' ||
+        window.location.hostname === 'localhost' ||
+        window.location.hostname === '127.0.0.1'
+      );
+    }
+
     function showApiAuthNotice(message) {
       apiAuthNotice.textContent = message;
       apiAuthNotice.classList.remove('hidden');
@@ -183,7 +192,7 @@
       apiAuthNotice.textContent = '';
     }
 
-    if (typeof window.CENSUS_API_KEY !== 'string' || !window.CENSUS_API_KEY) {
+    if ((typeof window.CENSUS_API_KEY !== 'string' || !window.CENSUS_API_KEY) && !isLocalRuntime()) {
       console.error('[imd-lookup] Missing CENSUS_API_KEY. APIM-protected requests may be rejected.');
       showApiAuthNotice('Requests are running without an API key. If APIM subscription validation is enabled, lookups may fail.');
     }
@@ -254,7 +263,7 @@
 
         url = withApiKey(url);
 
-        console.log('Fetching:', url);
+        console.log('[imd-lookup] Fetching IMD data for endpoint:', endpoint);
 
         const response = await fetch(url);
 

--- a/site/imd-lookup.html
+++ b/site/imd-lookup.html
@@ -150,9 +150,12 @@
       <p class="mt-4 text-gray-600">Loading...</p>
     </div>
 
+    <div id="api-auth-notice" class="hidden mb-6 rounded-lg border px-4 py-3 text-sm" style="background:#fff7ed;color:#9a3412;border-color:#fdba74;"></div>
+
     <div id="results" class="mt-8 hidden"></div>
   </div>
 
+  <script src="config.js?v=__ASSET_VERSION__"></script>
   <script>
     const yearsByCountry = {
       england: [2025, 2019],
@@ -168,6 +171,22 @@
     const form = document.getElementById('imd-form');
     const resultsDiv = document.getElementById('results');
     const loadingDiv = document.getElementById('loading');
+    const apiAuthNotice = document.getElementById('api-auth-notice');
+
+    function showApiAuthNotice(message) {
+      apiAuthNotice.textContent = message;
+      apiAuthNotice.classList.remove('hidden');
+    }
+
+    function hideApiAuthNotice() {
+      apiAuthNotice.classList.add('hidden');
+      apiAuthNotice.textContent = '';
+    }
+
+    if (typeof window.CENSUS_API_KEY !== 'string' || !window.CENSUS_API_KEY) {
+      console.error('[imd-lookup] Missing CENSUS_API_KEY. APIM-protected requests may be rejected.');
+      showApiAuthNotice('Requests are running without an API key. If APIM subscription validation is enabled, lookups may fail.');
+    }
 
     // Update year dropdown when country changes
     countrySelect.addEventListener('change', (e) => {
@@ -207,6 +226,14 @@
       });
     });
 
+    function withApiKey(urlString) {
+      const url = new URL(urlString);
+      if (typeof window.CENSUS_API_KEY === 'string' && window.CENSUS_API_KEY) {
+        url.searchParams.set('subscription-key', window.CENSUS_API_KEY);
+      }
+      return url.toString();
+    }
+
     async function fetchIMDData(endpoint) {
       const country = countrySelect.value;
       const year = yearSelect.value;
@@ -225,9 +252,18 @@
           url += `indices_of_multiple_deprivation?postcode=${encodeURIComponent(postcode)}&country=${country}&year=${year}`;
         }
 
+        url = withApiKey(url);
+
         console.log('Fetching:', url);
 
         const response = await fetch(url);
+
+        if (response.status === 401 || response.status === 403) {
+          console.error(`[imd-lookup] API key rejected with status ${response.status}.`);
+          showApiAuthNotice('The IMD API key is missing or invalid. Please check the deployed GitHub Pages secret or APIM subscription settings.');
+        } else {
+          hideApiAuthNotice();
+        }
         
         if (!response.ok) {
           const errorText = await response.text();

--- a/site/index.html
+++ b/site/index.html
@@ -122,6 +122,8 @@
     </div>
 </div>
 
+<div id="api-auth-notice" class="hidden" style="position:fixed;top:76px;right:20px;z-index:1001;max-width:420px;padding:12px 14px;border-radius:10px;background:#fff7ed;color:#9a3412;border:1px solid #fdba74;box-shadow:0 4px 15px rgba(0,0,0,0.12);"></div>
+
 <!-- Control Panel -->
 <div class="control-panel">
     <h2 style="margin-top:0; font-size: 1.2rem; color: #0d0d58; margin-bottom: 20px;">Map Controls</h2>

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -27,13 +27,13 @@ if (!TILES_BASE_URL) {
     "No tiles base URL configured. Set ?tilesBase=https://<host>/tiles, the rcpch-tiles-base-url meta tag, or inject window.PUBLIC_TILES_URL.",
   );
 
-// Append API key to TILES_BASE_URL if configured (for APIM authentication)
-let tilesUrl = TILES_BASE_URL;
-if (typeof window.CENSUS_API_KEY === "string" && window.CENSUS_API_KEY) {
-  const separator = tilesUrl.includes("?") ? "&" : "?";
-  tilesUrl = `${tilesUrl}${separator}subscription-key=${encodeURIComponent(window.CENSUS_API_KEY)}`;
-}
-const TILES_BASE_URL_WITH_AUTH = tilesUrl;
+  // Append API key to TILES_BASE_URL if configured (for APIM authentication)
+  let tilesUrl = TILES_BASE_URL;
+  if (typeof window.CENSUS_API_KEY === "string" && window.CENSUS_API_KEY) {
+    const separator = tilesUrl.includes("?") ? "&" : "?";
+    tilesUrl = `${tilesUrl}${separator}subscription-key=${encodeURIComponent(window.CENSUS_API_KEY)}`;
+  }
+  const TILES_BASE_URL_WITH_AUTH = tilesUrl;
 }
 
 const DATASET_INFO = {

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -26,6 +26,14 @@ if (!TILES_BASE_URL) {
   console.warn(
     "No tiles base URL configured. Set ?tilesBase=https://<host>/tiles, the rcpch-tiles-base-url meta tag, or inject window.PUBLIC_TILES_URL.",
   );
+
+// Append API key to TILES_BASE_URL if configured (for APIM authentication)
+let tilesUrl = TILES_BASE_URL;
+if (typeof window.CENSUS_API_KEY === "string" && window.CENSUS_API_KEY) {
+  const separator = tilesUrl.includes("?") ? "&" : "?";
+  tilesUrl = `${tilesUrl}${separator}subscription-key=${encodeURIComponent(window.CENSUS_API_KEY)}`;
+}
+const TILES_BASE_URL_WITH_AUTH = tilesUrl;
 }
 
 const DATASET_INFO = {
@@ -301,7 +309,7 @@ function initMap() {
 
   mapInstance = window.RcpchImdMap.createImdMap({
     container: "map",
-    tilesBaseUrl: TILES_BASE_URL,
+    tilesBaseUrl: TILES_BASE_URL_WITH_AUTH,
     initialNation: currentNation,
     initialEra: currentEra,
     areaTooltipMode: "template",

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -57,8 +57,12 @@ if (typeof window.CENSUS_API_KEY === "string" && window.CENSUS_API_KEY) {
   tilesUrl = `${tilesUrl}${separator}subscription-key=${encodeURIComponent(window.CENSUS_API_KEY)}`;
   hideApiAuthNotice();
 } else if (!isLocalRuntime()) {
-  console.error("[rcpch-imd-map] Missing CENSUS_API_KEY. APIM-protected map requests may be rejected.");
-  showApiAuthNotice("Map requests are running without an API key. If APIM subscription validation is enabled, the map may not load.");
+  console.error(
+    "[rcpch-imd-map] Missing CENSUS_API_KEY. APIM-protected map requests may be rejected.",
+  );
+  showApiAuthNotice(
+    "Map requests are running without an API key. If APIM subscription validation is enabled, the map may not load.",
+  );
 }
 const TILES_BASE_URL_WITH_AUTH = tilesUrl;
 
@@ -385,7 +389,8 @@ function initMap() {
     },
     onWarning(warning) {
       console.warn("[rcpch-imd-map]", warning.code, warning.message);
-      const warningText = `${warning.code || ""} ${warning.message || ""}`.toLowerCase();
+      const warningText =
+        `${warning.code || ""} ${warning.message || ""}`.toLowerCase();
       if (
         warningText.includes("401") ||
         warningText.includes("403") ||
@@ -394,8 +399,12 @@ function initMap() {
         warningText.includes("forbidden") ||
         warningText.includes("access denied")
       ) {
-        console.error("[rcpch-imd-map] API key rejected or missing for map requests.");
-        showApiAuthNotice("Map data could not be loaded because the API key is missing or invalid.");
+        console.error(
+          "[rcpch-imd-map] API key rejected or missing for map requests.",
+        );
+        showApiAuthNotice(
+          "Map data could not be loaded because the API key is missing or invalid.",
+        );
       }
     },
   });

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -26,15 +26,32 @@ if (!TILES_BASE_URL) {
   console.warn(
     "No tiles base URL configured. Set ?tilesBase=https://<host>/tiles, the rcpch-tiles-base-url meta tag, or inject window.PUBLIC_TILES_URL.",
   );
-
-  // Append API key to TILES_BASE_URL if configured (for APIM authentication)
-  let tilesUrl = TILES_BASE_URL;
-  if (typeof window.CENSUS_API_KEY === "string" && window.CENSUS_API_KEY) {
-    const separator = tilesUrl.includes("?") ? "&" : "?";
-    tilesUrl = `${tilesUrl}${separator}subscription-key=${encodeURIComponent(window.CENSUS_API_KEY)}`;
-  }
-  const TILES_BASE_URL_WITH_AUTH = tilesUrl;
 }
+
+const apiAuthNotice = document.getElementById("api-auth-notice");
+
+function showApiAuthNotice(message) {
+  if (!apiAuthNotice) return;
+  apiAuthNotice.textContent = message;
+  apiAuthNotice.classList.remove("hidden");
+}
+
+function hideApiAuthNotice() {
+  if (!apiAuthNotice) return;
+  apiAuthNotice.classList.add("hidden");
+  apiAuthNotice.textContent = "";
+}
+
+let tilesUrl = TILES_BASE_URL;
+if (typeof window.CENSUS_API_KEY === "string" && window.CENSUS_API_KEY) {
+  const separator = tilesUrl.includes("?") ? "&" : "?";
+  tilesUrl = `${tilesUrl}${separator}subscription-key=${encodeURIComponent(window.CENSUS_API_KEY)}`;
+  hideApiAuthNotice();
+} else {
+  console.error("[rcpch-imd-map] Missing CENSUS_API_KEY. APIM-protected map requests may be rejected.");
+  showApiAuthNotice("Map requests are running without an API key. If APIM subscription validation is enabled, the map may not load.");
+}
+const TILES_BASE_URL_WITH_AUTH = tilesUrl;
 
 const DATASET_INFO = {
   england: {
@@ -359,6 +376,18 @@ function initMap() {
     },
     onWarning(warning) {
       console.warn("[rcpch-imd-map]", warning.code, warning.message);
+      const warningText = `${warning.code || ""} ${warning.message || ""}`.toLowerCase();
+      if (
+        warningText.includes("401") ||
+        warningText.includes("403") ||
+        warningText.includes("subscription") ||
+        warningText.includes("unauthor") ||
+        warningText.includes("forbidden") ||
+        warningText.includes("access denied")
+      ) {
+        console.error("[rcpch-imd-map] API key rejected or missing for map requests.");
+        showApiAuthNotice("Map data could not be loaded because the API key is missing or invalid.");
+      }
     },
   });
 

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -30,6 +30,15 @@ if (!TILES_BASE_URL) {
 
 const apiAuthNotice = document.getElementById("api-auth-notice");
 
+function isLocalRuntime() {
+  return (
+    window.location.protocol === "file:" ||
+    window.location.hostname === "" ||
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1"
+  );
+}
+
 function showApiAuthNotice(message) {
   if (!apiAuthNotice) return;
   apiAuthNotice.textContent = message;
@@ -47,7 +56,7 @@ if (typeof window.CENSUS_API_KEY === "string" && window.CENSUS_API_KEY) {
   const separator = tilesUrl.includes("?") ? "&" : "?";
   tilesUrl = `${tilesUrl}${separator}subscription-key=${encodeURIComponent(window.CENSUS_API_KEY)}`;
   hideApiAuthNotice();
-} else {
+} else if (!isLocalRuntime()) {
   console.error("[rcpch-imd-map] Missing CENSUS_API_KEY. APIM-protected map requests may be rejected.");
   showApiAuthNotice("Map requests are running without an API key. If APIM subscription validation is enabled, the map may not load.");
 }


### PR DESCRIPTION
## Summary
- inject `RCPCH_CENSUS_PLATFORM_GITHUB_PAGES_API_KEY` into `site/config.js` during Pages deploy
- keep local dev behavior by leaving `window.CENSUS_API_KEY` optional in repo default config
- append `subscription-key` to the tiles URL only when `window.CENSUS_API_KEY` is present

## Why
This enables the GitHub Pages demo to call APIM-protected tile endpoints while preserving local `site/index.html` usage without requiring a key.