### PR TITLE
Fix map tile auth URL handling for APIM and bump imd-map

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -190,8 +190,8 @@ Update process for @rcpch/imd-map CDN pin:
 Then update both the @<version> in src and the integrity value below.
 -->
 <script
-    src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.0/dist/umd/rcpch-imd-map.min.js"
-    integrity="sha384-LDZdwn7z+54qTPkti5mXktF6aIIW5wLL5xu+/j0SkMtngO+lLZzx3o2r5jUjMURT"
+    src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.1/dist/umd/rcpch-imd-map.min.js"
+    integrity="sha384-UpOF5EyCHqp0AfvRXGaw/HTwfb4JxWrJaZqBDgh9ETsmqWVNjUN9LG4467DywbbM"
     crossorigin="anonymous"></script>
 <script src="map-logic.js?v=__ASSET_VERSION__"></script>
 

--- a/site/map-logic.js
+++ b/site/map-logic.js
@@ -28,6 +28,8 @@ if (!TILES_BASE_URL) {
   );
 }
 
+const TILE_API_KEY_PARAM = "subscription-key";
+
 const apiAuthNotice = document.getElementById("api-auth-notice");
 
 function isLocalRuntime() {
@@ -51,10 +53,12 @@ function hideApiAuthNotice() {
   apiAuthNotice.textContent = "";
 }
 
-let tilesUrl = TILES_BASE_URL;
-if (typeof window.CENSUS_API_KEY === "string" && window.CENSUS_API_KEY) {
-  const separator = tilesUrl.includes("?") ? "&" : "?";
-  tilesUrl = `${tilesUrl}${separator}subscription-key=${encodeURIComponent(window.CENSUS_API_KEY)}`;
+const TILE_API_KEY =
+  typeof window.CENSUS_API_KEY === "string" && window.CENSUS_API_KEY
+    ? window.CENSUS_API_KEY
+    : "";
+
+if (TILE_API_KEY) {
   hideApiAuthNotice();
 } else if (!isLocalRuntime()) {
   console.error(
@@ -64,7 +68,6 @@ if (typeof window.CENSUS_API_KEY === "string" && window.CENSUS_API_KEY) {
     "Map requests are running without an API key. If APIM subscription validation is enabled, the map may not load.",
   );
 }
-const TILES_BASE_URL_WITH_AUTH = tilesUrl;
 
 const DATASET_INFO = {
   england: {
@@ -339,7 +342,9 @@ function initMap() {
 
   mapInstance = window.RcpchImdMap.createImdMap({
     container: "map",
-    tilesBaseUrl: TILES_BASE_URL_WITH_AUTH,
+    tilesBaseUrl: TILES_BASE_URL,
+    tilesApiKey: TILE_API_KEY || undefined,
+    tilesApiKeyParam: TILE_API_KEY_PARAM,
     initialNation: currentNation,
     initialEra: currentEra,
     areaTooltipMode: "template",


### PR DESCRIPTION
## Summary
Fix map tile request auth handling in the site demo so tile URLs are constructed correctly when using an APIM query-parameter key, and update the mapping component to a version with native tile auth support.

## Changes
- Stop appending `subscription-key` directly onto `tilesBaseUrl` in the demo map bootstrap.
- Pass tile auth through native map options:
  - `tilesApiKey`
  - `tilesApiKeyParam` (`subscription-key`)
- Upgrade `@rcpch/imd-map` CDN bundle from `0.3.0` to `0.3.1`.
- Update SRI integrity hash to match the new bundle.

## Why
Appending query params to the base URL could produce malformed tile endpoints once path segments were added, which could surface as browser request/CORS failures. Using native tile auth options keeps URL construction valid and consistent.
