### PR TITLE
Pin GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot configuration.
+#
+# - Keeps GitHub Actions up to date.
+# - Actions are pinned to commit SHAs in workflows; Dependabot still
+#   recognises and updates SHA-pinned uses, preserving the trailing
+#   "# vX.Y.Z" version comment when it opens an update PR.
+# - The cooldown.default-days value gives 7 days between an upstream
+#   release and Dependabot raising a PR for it. This reduces exposure to
+#   compromised releases that get yanked or revoked shortly after publication
+#   (a common supply-chain attack pattern), while still keeping us current.
+#
+# Docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/deploy_containerapps.yml
+++ b/.github/workflows/deploy_containerapps.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Inject PUBLIC_TILES_URL config
         run: |
@@ -37,13 +37,13 @@ jobs:
           echo "window.CENSUS_API_KEY = '${{ secrets.RCPCH_CENSUS_PLATFORM_GITHUB_PAGES_API_KEY }}';" >> site/config.js
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload Pages artifact (site/)
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
             POSTCODES_IO_API_URL: https://api.postcodes.io
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Install system packages
               run: |


### PR DESCRIPTION
Pin third-party GitHub Actions to immutable commit SHAs (with a trailing version-tag comment for human readability) to mitigate supply-chain attacks via tag re-pointing. Add a Dependabot config that maintains the github-actions ecosystem with a 7-day cooldown so we don't adopt brand-new releases until any yanks/revocations have surfaced.

Each workflow has a header comment explaining the SHA-pinning convention and linking to the GitHub security-hardening docs and the mheap/pin-github-action tool.

Following process from @pacharanero in https://github.com/rcpch/rcpchgrowth-python/pull/87.