### PR TITLE
Fix mixed content warning for deployed Swagger UI

### DIFF
--- a/infra/nginx/default.conf
+++ b/infra/nginx/default.conf
@@ -45,7 +45,7 @@ server {
   location / {
     proxy_pass http://127.0.0.1:8000;
     proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 }

--- a/rcpch_census_platform/settings.py
+++ b/rcpch_census_platform/settings.py
@@ -194,6 +194,13 @@ SPECTACULAR_SETTINGS = {
 _csrf_origins = os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "")
 CSRF_TRUSTED_ORIGINS = [origin for origin in _csrf_origins.split(",") if origin]
 
+# Trust the X-Forwarded-Proto header set by the nginx reverse proxy so that
+# request.is_secure() / build_absolute_uri() report HTTPS behind a TLS-terminating
+# ingress (e.g. Azure Container Apps). Without this, swagger-ui's schema URL is
+# generated as http:// and browsers block it as mixed content.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+
 
 # Basic logging configuration for console output and app logger
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()


### PR DESCRIPTION
```
Fetch error
NetworkError when attempting to fetch resource. http://rcpch-census-platform-v2.greenrock-df7c746b.uksouth.azurecontainerapps.io/schema/
Fetch error
Possible mixed-content issue? The page was loaded over https:// but a http:// URL was specified. Check that you are not attempting to load mixed content.
```

Fix is to correctly use `scheme` on the root nginx endpoint (as we already do for the `/tiles/` endpoint) and also trust the forwarded hostname from Azure Container Apps.